### PR TITLE
use net 70 instead of net7.0 and csproj instead of sln

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,6 +25,6 @@ jobs:
 #    - name: Restore dependencies
 #      run: dotnet restore Sparked.Csv2FhirMapping/Sparked.Csv2FhirMapping.sln
     - name: Build
-      run: dotnet publish Sparked.Csv2FhirMapping/Sparked.Csv2FhirMapping.sln -r win-x64 -c Release -p:PublishSingleFile=True --framework netstandard2.0 --self-contained false
+      run: dotnet publish Sparked.Csv2FhirMapping/Sparked.Csv2FhirMapping.csproj -r win-x64 -c Release -p:PublishSingleFile=True --framework net70 --self-contained false --output "Sparked.Csv2FhirMappingOutput"
 #    - name: Test
 #      run: dotnet test --no-build --verbosity normal

--- a/Sparked.Csv2FhirMapping/Sparked.Csv2FhirMapping.csproj
+++ b/Sparked.Csv2FhirMapping/Sparked.Csv2FhirMapping.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net70</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/Sparked.TestDataClient/Sparked.TestDataClient.csproj
+++ b/Sparked.TestDataClient/Sparked.TestDataClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net70</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>TestDataClient</AssemblyName>


### PR DESCRIPTION
Publishing via csproj will avoid the single file error:

`/usr/local/share/dotnet/sdk/8.0.303/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(183,5): error NETSDK1099: Publishing to a single-file is only supported for executable applications. [/Users/pet260/Documents/repos/au-fhir-test-data-1/fhir-net-mappinglanguage/Hl7.Fhir.MappingLanguage/Hl7.Fhir.MappingLanguage.csproj::TargetFramework=net70]`


using net70 will align with the fhirnetmappinglanguage targets to prevent:
`Error: /usr/share/dotnet/sdk/8.0.303/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1005: Assets file '/home/runner/work/au-fhir-test-data/au-fhir-test-data/fhir-net-mappinglanguage/Hl7.Fhir.MappingLanguage/obj/project.assets.json' doesn't have a target for 'net7.0'. Ensure that restore has run and that you have included 'net7.0' in the TargetFrameworks for your project. [/home/runner/work/au-fhir-test-data/au-fhir-test-data/fhir-net-mappinglanguage/Hl7.Fhir.MappingLanguage/Hl7.Fhir.MappingLanguage.csproj::TargetFramework=net7.0]`