### PR TITLE
Add mapping for missing Immunization.occurrence and update StructureMap 

### DIFF
--- a/aups-forms/StructureMap-AUPatientSummaryExtract.json
+++ b/aups-forms/StructureMap-AUPatientSummaryExtract.json
@@ -3989,6 +3989,98 @@
                                                                                 }
                                                                             ],
                                                                             "documentation": "changed questionnaire to use dateTime rather than date"
+                                                                        },
+                                                                        {
+                                                                            "name": "6146d67097cd480eafa0a2ea0438eb87",
+                                                                            "source": [
+                                                                                {
+                                                                                    "context": "vaccinationadministeredeventItem",
+                                                                                    "condition": "(item.exists(linkId = 'immunizations-vaccinationadministeredevent-administrationDate').not())"
+                                                                                }
+                                                                            ],
+                                                                            "rule": [
+                                                                                {
+                                                                                    "name": "c1cd08c7347e42e2b23f6da56e9f8111",
+                                                                                    "source": [
+                                                                                        {
+                                                                                            "context": "vaccinationadministeredeventItem"
+                                                                                        }
+                                                                                    ],
+                                                                                    "target": [
+                                                                                        {
+                                                                                            "context": "immunization",
+                                                                                            "contextType": "variable",
+                                                                                            "element": "occurrence",
+                                                                                            "variable": "t_occurrence",
+                                                                                            "transform": "create",
+                                                                                            "parameter": [
+                                                                                                {
+                                                                                                    "valueString": "dateTime"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ],
+                                                                                    "rule": [
+                                                                                        {
+                                                                                            "name": "f6268fb056a849d887d3951e9156adcb",
+                                                                                            "source": [
+                                                                                                {
+                                                                                                    "context": "vaccinationadministeredeventItem"
+                                                                                                }
+                                                                                            ],
+                                                                                            "target": [
+                                                                                                {
+                                                                                                    "context": "t_occurrence",
+                                                                                                    "contextType": "variable",
+                                                                                                    "element": "extension",
+                                                                                                    "variable": "t_extension",
+                                                                                                    "listMode": [
+                                                                                                        "first"
+                                                                                                    ]
+                                                                                                }
+                                                                                            ],
+                                                                                            "rule": [
+                                                                                                {
+                                                                                                    "name": "9f541825fb0b4d0da6f4e6111cff14f5",
+                                                                                                    "source": [
+                                                                                                        {
+                                                                                                            "context": "vaccinationadministeredeventItem"
+                                                                                                        }
+                                                                                                    ],
+                                                                                                    "target": [
+                                                                                                        {
+                                                                                                            "context": "t_extension",
+                                                                                                            "contextType": "variable",
+                                                                                                            "element": "url",
+                                                                                                            "transform": "copy",
+                                                                                                            "parameter": [
+                                                                                                                {
+                                                                                                                    "valueString": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "context": "t_extension",
+                                                                                                            "contextType": "variable",
+                                                                                                            "element": "value",
+                                                                                                            "transform": "cast",
+                                                                                                            "parameter": [
+                                                                                                                {
+                                                                                                                    "valueString": "unknown"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "valueString": "code"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "documentation": "missing occurrence"
                                                                         }
                                                                     ]
                                                                 }

--- a/aups-forms/StructureMap-AUPatientSummaryExtract.map
+++ b/aups-forms/StructureMap-AUPatientSummaryExtract.map
@@ -415,7 +415,18 @@ group bundleMap(source src : QuestionnaireResponse, target bundle : Bundle) {
                                 // this causes an error in Smart Forms $extract
                                 answer.value as adate where (ofType(date).exists()) -> immunization.occurrence = cast(adate, 'dateTime');  
                                 // changed questionnaire to use dateTime rather than date
-                                answer.value as adate where (ofType(dateTime).exists()) -> immunization.occurrence = adate;  
+                                answer.value as adate where (ofType(dateTime).exists()) -> immunization.occurrence = adate;
+                                
+                                // missing occurrence
+                                //tried answer.value as adate where (answer.empty())
+                                //tried answer.value as adate where length() = 0
+                                //reference: https://github.com/hl7au/au-fhir-test-data/blob/fix-terminology-discrepancy/Sparked.Csv2FhirMapping/Maps/CSV2Immunization.map#L110C1-L116C7
+                                answer.value as adate where (answer.exists().not) -> immunization.occurrence = create('dateTime') as t_occurrence then {
+                                    adate -> t_occurrence.extension as t_extension first then {
+                                        adate -> t_extension.url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+                                        t_extension.value = cast('unknown', 'code');
+                                    };
+                                };
                             };
                         };
                         

--- a/aups-forms/StructureMap-AUPatientSummaryExtract.map
+++ b/aups-forms/StructureMap-AUPatientSummaryExtract.map
@@ -418,14 +418,13 @@ group bundleMap(source src : QuestionnaireResponse, target bundle : Bundle) {
                                 answer.value as adate where (ofType(dateTime).exists()) -> immunization.occurrence = adate;
                                 
                                 // missing occurrence
-                                //tried answer.value as adate where (answer.empty())
-                                //tried answer.value as adate where length() = 0
-                                //reference: https://github.com/hl7au/au-fhir-test-data/blob/fix-terminology-discrepancy/Sparked.Csv2FhirMapping/Maps/CSV2Immunization.map#L110C1-L116C7
-                                answer.value as adate where (answer.exists().not) -> immunization.occurrence = create('dateTime') as t_occurrence then {
-                                    adate -> t_occurrence.extension as t_extension first then {
-                                        adate -> t_extension.url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
-                                        t_extension.value = cast('unknown', 'code');
-                                    };
+                                vaccinationadministeredeventItem where (item.exists(linkId = 'immunizations-vaccinationadministeredevent-administrationDate').not()) then {
+                                    vaccinationadministeredeventItem -> immunization.occurrence = create('dateTime') as t_occurrence then {
+                                            vaccinationadministeredeventItem -> t_occurrence.extension as t_extension first then {
+                                                vaccinationadministeredeventItem -> t_extension.url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+                                                t_extension.value = cast('unknown', 'code');
+                                            };
+                                        };
                                 };
                             };
                         };

--- a/aups-forms/StructureMap-AUPatientSummaryExtract.map
+++ b/aups-forms/StructureMap-AUPatientSummaryExtract.map
@@ -416,6 +416,11 @@ group bundleMap(source src : QuestionnaireResponse, target bundle : Bundle) {
                                 answer.value as adate where (ofType(date).exists()) -> immunization.occurrence = cast(adate, 'dateTime');  
                                 // changed questionnaire to use dateTime rather than date
                                 answer.value as adate where (ofType(dateTime).exists()) -> immunization.occurrence = adate;  
+                                // Handle missing data using Data Absent Reason extension
+                                check administrationDate.answer.empty() then {
+                                immunization.occurrence.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason";
+                                immunization.occurrence.extension.valueCode = "unknown";
+                                };
                             };
                         };
                         

--- a/aups-forms/StructureMap-AUPatientSummaryExtract.map
+++ b/aups-forms/StructureMap-AUPatientSummaryExtract.map
@@ -416,11 +416,6 @@ group bundleMap(source src : QuestionnaireResponse, target bundle : Bundle) {
                                 answer.value as adate where (ofType(date).exists()) -> immunization.occurrence = cast(adate, 'dateTime');  
                                 // changed questionnaire to use dateTime rather than date
                                 answer.value as adate where (ofType(dateTime).exists()) -> immunization.occurrence = adate;  
-                                // Handle missing data using Data Absent Reason extension
-                                check administrationDate.answer.empty() then {
-                                immunization.occurrence.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason";
-                                immunization.occurrence.extension.valueCode = "unknown";
-                                };
                             };
                         };
                         


### PR DESCRIPTION
- Added a mapping rule to handle missing mandatory data in `Immunization.occurrence[x]`
- Updated the converted FHIR StructureMap
- Successfully uploaded the StructureMap to the https://smartforms.csiro.au/api/fhir server via http PUT request

Closes #99