### PR TITLE
AU Core RelatedPerson test data

### DIFF
--- a/aucore/RelatedPerson-ballantyne-flavia-2.json
+++ b/aucore/RelatedPerson-ballantyne-flavia-2.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "ballantyne-flavia-2",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608833648488"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "69518260311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/ballantyne-kelvin-hans"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "WIFE",
+          "display": "wife"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BALLANTYNE",
+      "given": [
+        "Flavia",
+        "INDIRA"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106296",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491570110",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870101585",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1973-06-17",
+  "address": [
+    {
+      "line": [
+        "73 Abattoir Gdns"
+      ],
+      "city": "Wellington Forest",
+      "state": "WA",
+      "postalCode": "6236",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-ballantyne-flavia-3.json
+++ b/aucore/RelatedPerson-ballantyne-flavia-3.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "ballantyne-flavia-3",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608833648488"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "69518260311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/ballantyne-sandy-choy"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "MTH",
+          "display": "mother"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BALLANTYNE",
+      "given": [
+        "Flavia",
+        "INDIRA"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106296",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491570110",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870101585",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1973-06-17",
+  "address": [
+    {
+      "line": [
+        "73 Abattoir Gdns"
+      ],
+      "city": "Wellington Forest",
+      "state": "WA",
+      "postalCode": "6236",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-ballantyne-flavia-4.json
+++ b/aucore/RelatedPerson-ballantyne-flavia-4.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "ballantyne-flavia-4",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608833648488"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "69518260311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/ballantyne-terry-bob"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "MTH",
+          "display": "mother"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BALLANTYNE",
+      "given": [
+        "Flavia",
+        "INDIRA"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106296",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491570110",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870101585",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1973-06-17",
+  "address": [
+    {
+      "line": [
+        "73 Abattoir Gdns"
+      ],
+      "city": "Wellington Forest",
+      "state": "WA",
+      "postalCode": "6236",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-ballantyne-sandy.json
+++ b/aucore/RelatedPerson-ballantyne-sandy.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "ballantyne-sandy",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608333647279"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "69518260313"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/terry-bob-ballantyne"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "SIB",
+          "display": "sibling"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BALLANTYNE",
+      "given": [
+        "Sandy",
+        "CHOY"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106296",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491570737",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870100699",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2001-01-02",
+  "address": [
+    {
+      "line": [
+        "73 Abattoir Gdns"
+      ],
+      "city": "Wellington Forest",
+      "state": "WA",
+      "postalCode": "6236",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-ballantyne-terry.json
+++ b/aucore/RelatedPerson-ballantyne-terry.json
@@ -1,0 +1,102 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "ballantyne-terry",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608333647287"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "69518260314"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/ballantyne-sandy-choy"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "SIB",
+          "display": "sibling"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BALLANTYNE",
+      "given": [
+        "Terry",
+        "BOB"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106296",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491571266",
+      "use": "mobile"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2004-08-07",
+  "address": [
+    {
+      "line": [
+        "73 Abattoir Gdns"
+      ],
+      "city": "Wellington Forest",
+      "state": "WA",
+      "postalCode": "6236",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-banks-jeramy-2.json
+++ b/aucore/RelatedPerson-banks-jeramy-2.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "banks-jeramy-2",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608166980417"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "29545410411"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/banks-mia-leanne"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "HUSB",
+          "display": "husband"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BANKS",
+      "given": [
+        "Jeramy",
+        "EZRA"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0270107520",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491574118",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0270101153",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1971-05-14",
+  "address": [
+    {
+      "line": [
+        "50 Sebastien St"
+      ],
+      "city": "Minjary",
+      "state": "NSW",
+      "postalCode": "2720",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-banks-jeramy-3.json
+++ b/aucore/RelatedPerson-banks-jeramy-3.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "banks-jeramy-3",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608166980417"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "29545410411"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/banks-jonas-cary"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "FTH",
+          "display": "father"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BANKS",
+      "given": [
+        "Jeramy",
+        "EZRA"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0270107520",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491574118",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0270101153",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1971-05-14",
+  "address": [
+    {
+      "line": [
+        "50 Sebastien St"
+      ],
+      "city": "Minjary",
+      "state": "NSW",
+      "postalCode": "2720",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-banks-jeramy-4.json
+++ b/aucore/RelatedPerson-banks-jeramy-4.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "banks-jeramy-4",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608166980417"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "29545410411"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/banks-jamila-angie"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "FTH",
+          "display": "father"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "BANKS",
+      "given": [
+        "Jeramy",
+        "EZRA"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0270107520",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491574118",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0270101153",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1971-05-14",
+  "address": [
+    {
+      "line": [
+        "50 Sebastien St"
+      ],
+      "city": "Minjary",
+      "state": "NSW",
+      "postalCode": "2720",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-banks-mia-leanne.json
+++ b/aucore/RelatedPerson-banks-mia-leanne.json
@@ -1,0 +1,173 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "banks-mia-leanne",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "value",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "446141000124107",
+                "display": "Identifies as female gender (finding)"
+              }
+            ]
+          }
+        }
+      ],
+      "url": "http://hl7.org/fhir/StructureDefinition/individual-genderIdentity"
+    },
+    {
+      "extension": [
+        {
+          "url": "value",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "LA29519-8",
+                "display": "she/her/her/hers/herself"
+              }
+            ]
+          }
+        }
+      ],
+      "url": "http://hl7.org/fhir/StructureDefinition/individual-pronouns"
+    },
+    {
+      "extension": [
+        {
+          "url": "type",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "1515311000168102",
+                "display": "Biological sex at birth"
+              }
+            ]
+          }
+        },
+        {
+          "url": "value",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "248152002",
+                "display": "Female"
+              }
+            ]
+          }
+        }
+      ],
+      "url": "http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender"
+    }
+  ],
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608333647261"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "29545410412"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/baby-banks-john"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "MTH",
+          "display": "mother"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "use": "official",
+      "family": "BANKS",
+      "given": [
+        "Mia",
+        "LEANNE"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0270107520",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491574632",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0270102724",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1983-08-25",
+  "address": [
+    {
+      "line": [
+        "50 Sebastien St"
+      ],
+      "city": "Minjary",
+      "state": "NSW",
+      "postalCode": "2720",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-dietrich-phillipa-2.json
+++ b/aucore/RelatedPerson-dietrich-phillipa-2.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "dietrich-phillipa-2",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608666976485"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "29545411311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/dietrich-blake-louis"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "MTH",
+          "display": "mother"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "DIETRICH",
+      "given": [
+        "Phillipa",
+        "GRACE"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0270109317",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0433350288",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0270103810",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1985-06-16",
+  "address": [
+    {
+      "line": [
+        "77 Yoga Rdge"
+      ],
+      "city": "Mitchell",
+      "state": "ACT",
+      "postalCode": "2911",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-dietrich-phillipa-3.json
+++ b/aucore/RelatedPerson-dietrich-phillipa-3.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "dietrich-phillipa-3",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608666976485"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "29545411311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/dietrich-kimbra-althea"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "MTH",
+          "display": "mother"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "DIETRICH",
+      "given": [
+        "Phillipa",
+        "GRACE"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0270109317",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0433350288",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0270103810",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1985-06-16",
+  "address": [
+    {
+      "line": [
+        "77 Yoga Rdge"
+      ],
+      "city": "Mitchell",
+      "state": "ACT",
+      "postalCode": "2911",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-dietrich-phillipa-4.json
+++ b/aucore/RelatedPerson-dietrich-phillipa-4.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "dietrich-phillipa-4",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608666976485"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "29545411311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/dietrich-diedre-alicia"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "MTH",
+          "display": "mother"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "DIETRICH",
+      "given": [
+        "Phillipa",
+        "GRACE"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0270109317",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0433350288",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0270103810",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1985-06-16",
+  "address": [
+    {
+      "line": [
+        "77 Yoga Rdge"
+      ],
+      "city": "Mitchell",
+      "state": "ACT",
+      "postalCode": "2911",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-mackay-heather-2.json
+++ b/aucore/RelatedPerson-mackay-heather-2.json
@@ -1,0 +1,142 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "mackay-heather-2",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "value",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "446151000124109",
+                "display": "Identifies as male gender (finding)"
+              }
+            ]
+          }
+        }
+      ],
+      "url": "http://hl7.org/fhir/StructureDefinition/individual-genderIdentity"
+    },
+    {
+      "extension": [
+        {
+          "url": "value",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "LA29520-6",
+                "display": "they/them/their/theirs/themselves"
+              }
+            ]
+          }
+        }
+      ],
+      "url": "http://hl7.org/fhir/StructureDefinition/individual-pronouns"
+    }
+  ],
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608666976451"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "39513341311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/mackay-fritz"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "SPS",
+          "display": "spouse"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "MACKAY",
+      "given": [
+        "Heather"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0370108075",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491578148",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0370103228",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1982-11-27",
+  "address": [
+    {
+      "line": [
+        "28 Stone Cr"
+      ],
+      "city": "Appin South",
+      "state": "VIC",
+      "postalCode": "3579",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-mackay-heather-3.json
+++ b/aucore/RelatedPerson-mackay-heather-3.json
@@ -1,0 +1,142 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "mackay-heather-3",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "value",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "446151000124109",
+                "display": "Identifies as male gender (finding)"
+              }
+            ]
+          }
+        }
+      ],
+      "url": "http://hl7.org/fhir/StructureDefinition/individual-genderIdentity"
+    },
+    {
+      "extension": [
+        {
+          "url": "value",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "LA29520-6",
+                "display": "they/them/their/theirs/themselves"
+              }
+            ]
+          }
+        }
+      ],
+      "url": "http://hl7.org/fhir/StructureDefinition/individual-pronouns"
+    }
+  ],
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608666976451"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "39513341311"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/mackay-elliott"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "PRN",
+          "display": "parent"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "MACKAY",
+      "given": [
+        "Heather"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0370108075",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491578148",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0370103228",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1982-11-27",
+  "address": [
+    {
+      "line": [
+        "28 Stone Cr"
+      ],
+      "city": "Appin South",
+      "state": "VIC",
+      "postalCode": "3579",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-veitch-miles-2.json
+++ b/aucore/RelatedPerson-veitch-miles-2.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "veitch-miles-2",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608000311795"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "49516522811"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/veitch-savannah-sheena"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "FTH",
+          "display": "father"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "VEITCH",
+      "given": [
+        "Miles",
+        "DUDLEY"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106485",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491573770",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870105678",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1994-04-10",
+  "address": [
+    {
+      "line": [
+        "78 Innovation Cct"
+      ],
+      "city": "Newcastle Waters",
+      "state": "NT",
+      "postalCode": "0862",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-veitch-miles-3.json
+++ b/aucore/RelatedPerson-veitch-miles-3.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "veitch-miles-3",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608000311795"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "49516522811"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/veitch-mitchell-carl"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "FTH",
+          "display": "father"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "VEITCH",
+      "given": [
+        "Miles",
+        "DUDLEY"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106485",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491573770",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870105678",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1994-04-10",
+  "address": [
+    {
+      "line": [
+        "78 Innovation Cct"
+      ],
+      "city": "Newcastle Waters",
+      "state": "NT",
+      "postalCode": "0862",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-veitch-miles-4.json
+++ b/aucore/RelatedPerson-veitch-miles-4.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "veitch-miles-4",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608000311795"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "49516522811"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/veitch-beau-bradley"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "FTH",
+          "display": "father"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "VEITCH",
+      "given": [
+        "Miles",
+        "DUDLEY"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106485",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491573770",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870105678",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1994-04-10",
+  "address": [
+    {
+      "line": [
+        "78 Innovation Cct"
+      ],
+      "city": "Newcastle Waters",
+      "state": "NT",
+      "postalCode": "0862",
+      "country": "AU"
+    }
+  ]
+}

--- a/aucore/RelatedPerson-veitch-miles-5.json
+++ b/aucore/RelatedPerson-veitch-miles-5.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "RelatedPerson",
+  "id": "veitch-miles-5",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"
+    ]
+  },
+  "identifier": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-status-1",
+            "code": "active"
+          }
+        },
+        {
+          "url": "http://hl7.org.au/fhir/StructureDefinition/ihi-record-status",
+          "valueCoding": {
+            "system": "https://healthterminologies.gov.au/fhir/CodeSystem/ihi-record-status-1",
+            "code": "verified",
+            "display": "verified"
+          }
+        }
+      ],
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NI"
+          }
+        ],
+        "text": "IHI"
+      },
+      "system": "http://ns.electronichealth.net.au/id/hi/ihi/1.0",
+      "value": "8003608000311795"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MC"
+          }
+        ],
+        "text": "Medicare Number"
+      },
+      "system": "http://ns.electronichealth.net.au/id/medicare-number",
+      "value": "49516522811"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/veitch-nathan-chris"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "FTH",
+          "display": "father"
+        }
+      ]
+    }
+  ],
+  "name": [
+    {
+      "family": "VEITCH",
+      "given": [
+        "Miles",
+        "DUDLEY"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0870106485",
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "0491573770",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "0870105678",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1994-04-10",
+  "address": [
+    {
+      "line": [
+        "78 Innovation Cct"
+      ],
+      "city": "Newcastle Waters",
+      "state": "NT",
+      "postalCode": "0862",
+      "country": "AU"
+    }
+  ]
+}


### PR DESCRIPTION
Test data for AU Core RelatedPerson. 

- manual assessment of test data coverage of _Must Support_ elements is 100%. Inferno test suite for AU Core RelatedPerson not yet available so could not be used to verify manual check. 
- Validation report for conformance against AU Core attached below:
  - FHIR Validator params: `-version 4.0.1 -ig hl7.fhir.au.core -tx https://tx.dev.hl7.org.au/fhir` 
  - [g_validation.zip](https://github.com/user-attachments/files/19101519/g_validation.zip) 
    - 1 error reported but it appears to be a potential issue with tx.dev rather than a valid conformance issue.
    - revalidation against https://tx.ontoserver.csiro.au/fhir produced no errors.
  