### PR TITLE
Add MedicationStatement examples from AU Core IG 

### DIFF
--- a/direct-fhir-test-resources/MedicationStatement-active-bisoprolol.json
+++ b/direct-fhir-test-resources/MedicationStatement-active-bisoprolol.json
@@ -1,0 +1,30 @@
+{
+  "resourceType" : "MedicationStatement",
+  "id" : "active-bisoprolol",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationstatement"]
+  },
+  "contained" : [{
+    "resourceType" : "Medication",
+    "id" : "bisoprolol",
+    "code" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "23281011000036106",
+        "display" : "Bisoprolol fumarate 2.5 mg tablet"
+      }],
+      "text" : "Bisoprolol 2.5mg tab"
+    }
+  }],
+  "status" : "active",
+  "medicationReference" : {
+    "reference" : "#bisoprolol"
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "dateAsserted" : "2019-02-05",
+  "dosage" : [{
+    "text" : "1/2 tablet in the morning"
+  }]
+}

--- a/direct-fhir-test-resources/MedicationStatement-completed-bactrim.json
+++ b/direct-fhir-test-resources/MedicationStatement-completed-bactrim.json
@@ -1,0 +1,31 @@
+{
+  "resourceType" : "MedicationStatement",
+  "id" : "completed-bactrim",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationstatement"]
+  },
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: MedicationStatement completed-bactrim</b></p><a name=\"completed-bactrim\"> </a><a name=\"hccompleted-bactrim\"> </a><a name=\"completed-bactrim-en-AU\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-au-core-medicationstatement.html\">AU Core MedicationStatement</a></p></div><p><b>status</b>: Completed</p><p><b>medication</b>: <span title=\"Codes:{http://snomed.info/sct 6632011000036102}, {http://pbs.gov.au/code/item 2951H}\">Bactrim DS - tablet</span></p><p><b>subject</b>: <a href=\"Patient-banks-mia-leanne.html\">Mia Leanne Banks  Female, DoB: 1983-08-25 ( IHI:\u00a0Austalian Healthcare Identifier - Individual#8003608333647261)</a></p><p><b>dateAsserted</b>: 2020-05-30 10:00:00+1000</p><p><b>reasonReference</b>: <a href=\"Condition-uti.html\">Condition Urinary tract infection</a></p></div>"
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "6632011000036102",
+      "display" : "Bactrim DS tablet"
+    },
+    {
+      "system" : "http://pbs.gov.au/code/item",
+      "code" : "2951H"
+    }],
+    "text" : "Bactrim DS - tablet"
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "dateAsserted" : "2020-05-30T10:00:00+10:00",
+  "reasonReference" : [{
+    "reference" : "Condition/uti"
+  }]
+}

--- a/direct-fhir-test-resources/MedicationStatement-completed-chloramphenicol.json
+++ b/direct-fhir-test-resources/MedicationStatement-completed-chloramphenicol.json
@@ -1,0 +1,27 @@
+{
+  "resourceType" : "MedicationStatement",
+  "id" : "completed-chloramphenicol",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationstatement"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "22717011000036101",
+      "display" : "Chloramphenicol 1% eye ointment"
+    }],
+    "text" : "Chloramphenicol 1% eye ointment"
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "dateAsserted" : "2019-02-05",
+  "reasonCode" : [{
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "719755001"
+    }],
+    "text" : "Adult gonococcal conjunctivitis"
+  }]
+}

--- a/direct-fhir-test-resources/MedicationStatement-previous-use-diflucan.json
+++ b/direct-fhir-test-resources/MedicationStatement-previous-use-diflucan.json
@@ -1,0 +1,60 @@
+{
+  "resourceType" : "MedicationStatement",
+  "id" : "previous-use-diflucan",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationstatement"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "extension" : [{
+        "url" : "http://hl7.org.au/fhir/StructureDefinition/medication-type",
+        "valueCoding" : {
+          "system" : "http://terminology.hl7.org.au/CodeSystem/medication-type",
+          "code" : "BPDSF",
+          "display" : "Branded product with strengths and form"
+        }
+      }],
+      "system" : "http://snomed.info/sct",
+      "code" : "5232011000036102",
+      "display" : "Diflucan 200 mg/100 mL injection, 100 mL vial"
+    }]
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "effectivePeriod" : {
+    "start" : "2018-06-25",
+    "end" : "2018-07-05"
+  },
+  "dateAsserted" : "2018-07-10",
+  "dosage" : [{
+    "text" : "Every 1-10 days at 10am for 30 minutes",
+    "timing" : {
+      "repeat" : {
+        "duration" : 30,
+        "durationUnit" : "min",
+        "frequency" : 1,
+        "period" : 1,
+        "periodMax" : 10,
+        "periodUnit" : "d",
+        "timeOfDay" : ["10:00:00"]
+      }
+    },
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "47625008",
+        "display" : "Intravenous route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 200,
+        "unit" : "mg",
+        "system" : "http://unitsofmeasure.org",
+        "code" : "mg"
+      }
+    }]
+  }]
+}


### PR DESCRIPTION
Closes https://github.com/hl7au/au-fhir-test-data/issues/129

Addition of set of MedicationStatement example resources to demonstrate [AU Core MedicationStatement](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-medicationstatement.html) profile. The set of examples is provided to a patient of interest for Inferno - Mia Leanne Banks.

_NOTE: AU Core IG Examples are constructed in line with the following principles: https://confluence.hl7.org/spaces/HAFWG/pages/325457088/AU+Core+FHIR+IG+Examples+Principles_

The set of JSON examples pulled from the AU Core IG and the text field removed but are otherwise unchanged. The set of examples are intended to demonstrate:
- an instance of all elements and slices flagged with Must Support
- profile specific implementation guidance on contained medication (i.e. an instance of a contained medication)
- profile specific implementation guidance on reasonCode OR reasonReference
- [Medicine Information](https://build.fhir.org/ig/hl7au/au-fhir-core/medicine-information.html) page
- Addiditional AUCDI elements mapped to dosage but not flagged with Must Support. See https://build.fhir.org/ig/hl7au/au-fhir-core/aucdi.html#aucdi-mappings-into-au-core

Referential Integrity:

- All instances of subject are a relative reference to Patient resource: https://github.com/hl7au/au-fhir-test-data/blob/master/generated/Patient-banks-mia-leanne.json
- reasonReference is a relative reference to Condition resource: https://github.com/hl7au/au-fhir-test-data/blob/master/generated/Condition-uti.json

_NOTE: This set does not provide an instance of a suppressed data element, or full missing data coverage._