### PR TITLE
Added AU Core related person examples (+ missing patient wang li)

### DIFF
--- a/au-fhir-test-data-set/Patient-wang-li.json
+++ b/au-fhir-test-data-set/Patient-wang-li.json
@@ -1,0 +1,55 @@
+{
+  "resourceType" : "Patient",
+  "id" : "wang-li",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"]
+  },
+  "extension" : [{
+    "url" : "http://hl7.org.au/fhir/StructureDefinition/indigenous-status",
+    "valueCoding" : {
+      "system" : "https://healthterminologies.gov.au/fhir/CodeSystem/australian-indigenous-status-1",
+      "code" : "4",
+      "display" : "Neither Aboriginal nor Torres Strait Islander origin"
+    }
+  }],
+  "identifier" : [{
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+        "code" : "MR",
+        "display" : "Medical record number"
+      }],
+      "text" : "Medical Record Number"
+    },
+    "system" : "http://ns.electronichealth.net.au/id/hpio-scoped/medicalrecord/1.0/8003626566699734",
+    "value" : "22421441",
+    "assigner" : {
+      "display" : "Mount Mitchell Private Hospital"
+    }
+  }],
+  "name" : [{
+    "family" : "Wang",
+    "given" : ["Li"],
+    "prefix" : ["Mr"]
+  }],
+  "gender" : "male",
+  "birthDate" : "1975-05-03",
+  "address" : [{
+    "use" : "home",
+    "line" : ["29 Gadsby Street"],
+    "city" : "Blacktown",
+    "state" : "NSW",
+    "postalCode" : "2148",
+    "country" : "AU"
+  }],
+  "communication" : [{
+    "language" : {
+      "coding" : [{
+        "system" : "urn:ietf:bcp:47",
+        "code" : "yue"
+      }],
+      "text" : "Cantonese"
+    },
+    "preferred" : true
+  }]
+}

--- a/au-fhir-test-data-set/RelatedPerson-banks-bob.json
+++ b/au-fhir-test-data-set/RelatedPerson-banks-bob.json
@@ -1,0 +1,21 @@
+{
+  "resourceType" : "RelatedPerson",
+  "id" : "banks-bob",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"]
+  },
+  "patient" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "relationship" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "code" : "FTH"
+    }],
+    "text" : "Father"
+  }],
+  "name" : [{
+    "family" : "Banks",
+    "given" : ["Bob"]
+  }]
+}

--- a/au-fhir-test-data-set/RelatedPerson-rabbit-peter.json
+++ b/au-fhir-test-data-set/RelatedPerson-rabbit-peter.json
@@ -1,0 +1,41 @@
+{
+  "resourceType" : "RelatedPerson",
+  "id" : "rabbit-peter",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-relatedperson"]
+  },
+  "patient" : {
+    "reference" : "Patient/wang-li"
+  },
+  "relationship" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "code" : "FRND",
+      "display" : "unrelated friend"
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v2-0131",
+      "code" : "C",
+      "display" : "Emergency Contact"
+    }]
+  }],
+  "name" : [{
+    "use" : "usual",
+    "family" : "Rabbit",
+    "given" : ["Peter",
+    "Rabbit"]
+  }],
+  "telecom" : [{
+    "system" : "phone",
+    "value" : "07 853 9191",
+    "use" : "home"
+  }],
+  "address" : [{
+    "use" : "home",
+    "line" : ["29 Gadsby Street"],
+    "city" : "Blacktown",
+    "state" : "NSW",
+    "postalCode" : "2148",
+    "country" : "AU"
+  }]
+}


### PR DESCRIPTION
Addresses #145 by adding the related person examples to demonstrate the [AU Core RelatedPerson](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-relatedperson.html) mandatory and must support elements.

In addition, it was noted that the AU Core patient persona of Mr. Li Wang is missing. This is also submitted as part of this PR.