### PR TITLE
Update AU Core AllergyIntolerance example to include .note Must Support element

### DIFF
--- a/au-fhir-test-data-set/AllergyIntolerance-penicillin.json
+++ b/au-fhir-test-data-set/AllergyIntolerance-penicillin.json
@@ -29,6 +29,11 @@
     "reference": "Patient/irvine-ronny-lawrence"
   },
   "recordedDate": "1999-08-25",
+  "note" : [
+    {
+      "text" : "The criticality is high due to a documented episode of hives following penicillin administration."
+    }
+  ],
   "reaction": [
     {
       "manifestation": [


### PR DESCRIPTION
Update AU Core IG example to include AllergyIntolerance.note element, voted to be flagged as Must Support element in AU Core AllergyIntolerance. Related JIRA [FHIR-4694](https://jira.hl7.org/browse/FHIR-46940).  

Related AU Core change: [AU Core PR #352](https://github.com/hl7au/au-fhir-core/pull/352)