### PR TITLE
Fix code / display mismatch in reason for encounter - Influenza vaccination

### DIFF
--- a/au-fhir-test-data-set/au-core/Encounter-influenza-admin-1.json
+++ b/au-fhir-test-data-set/au-core/Encounter-influenza-admin-1.json
@@ -51,8 +51,8 @@
       "coding": [
         {
           "system": "http://snomed.info/sct",
-          "code": "12866006",
-          "display": "Influenza prevention"
+          "code": "185903001",
+          "display": "Needs influenza vaccination"
         }
       ]
     }

--- a/au-fhir-test-data-set/au-core/Encounter-influenza-admin-2.json
+++ b/au-fhir-test-data-set/au-core/Encounter-influenza-admin-2.json
@@ -51,8 +51,8 @@
       "coding": [
         {
           "system": "http://snomed.info/sct",
-          "code": "12866006",
-          "display": "Influenza prevention"
+          "code": "185903001",
+          "display": "Needs influenza vaccination"
         }
       ]
     }

--- a/au-fhir-test-data-set/au-core/Encounter-influenza-admin-3.json
+++ b/au-fhir-test-data-set/au-core/Encounter-influenza-admin-3.json
@@ -51,8 +51,8 @@
       "coding": [
         {
           "system": "http://snomed.info/sct",
-          "code": "12866006",
-          "display": "Influenza prevention"
+          "code": "185903001",
+          "display": "Needs influenza vaccination"
         }
       ]
     }

--- a/au-fhir-test-data-set/au-core/Encounter-influenza-admin-4.json
+++ b/au-fhir-test-data-set/au-core/Encounter-influenza-admin-4.json
@@ -51,8 +51,8 @@
       "coding": [
         {
           "system": "http://snomed.info/sct",
-          "code": "12866006",
-          "display": "Influenza prevention"
+          "code": "185903001",
+          "display": "Needs influenza vaccination"
         }
       ]
     }

--- a/au-fhir-test-data-set/au-core/Encounter-influenza-admin-5.json
+++ b/au-fhir-test-data-set/au-core/Encounter-influenza-admin-5.json
@@ -51,8 +51,8 @@
       "coding": [
         {
           "system": "http://snomed.info/sct",
-          "code": "12866006",
-          "display": "Influenza prevention"
+          "code": "185903001",
+          "display": "Needs influenza vaccination"
         }
       ]
     }

--- a/au-fhir-test-data-set/au-core/Encounter-influenza-admin-6.json
+++ b/au-fhir-test-data-set/au-core/Encounter-influenza-admin-6.json
@@ -51,8 +51,8 @@
       "coding": [
         {
           "system": "http://snomed.info/sct",
-          "code": "12866006",
-          "display": "Influenza prevention"
+          "code": "185903001",
+          "display": "Needs influenza vaccination"
         }
       ]
     }

--- a/au-fhir-test-data-set/au-core/Encounter-influenza-admin-7.json
+++ b/au-fhir-test-data-set/au-core/Encounter-influenza-admin-7.json
@@ -51,8 +51,8 @@
       "coding": [
         {
           "system": "http://snomed.info/sct",
-          "code": "12866006",
-          "display": "Influenza prevention"
+          "code": "185903001",
+          "display": "Needs influenza vaccination"
         }
       ]
     }


### PR DESCRIPTION
With reference to the 7 Influenza vaccination encounter instances
- Updated Coding in all Encounter.reasonCode to use 185903001 | Needs influenza immunization | instead of 12866006 | Administration of pneumococcal vaccine |.