### PR TITLE
Correct blood group results

### DIFF
--- a/au-fhir-test-data-set/au-core/Observation-blood-group.json
+++ b/au-fhir-test-data-set/au-core/Observation-blood-group.json
@@ -36,10 +36,10 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "112144000",
-        "display": "Blood group A (finding)"
+        "code": "278149003",
+        "display": "Blood group A Rh(D) positive"
       }
     ],
-    "text": "A"
+    "text": "A Rh(D) Positive"
   }
 }

--- a/au-fhir-test-data-set/au-core/Observation-rh-status.json
+++ b/au-fhir-test-data-set/au-core/Observation-rh-status.json
@@ -40,6 +40,6 @@
         "display": "Negative"
       }
     ],
-    "text": "RhD positive"
+    "text": "Negative"
   }
 }


### PR DESCRIPTION
Correct two inconsistencies with the example of Blood Group and Antibody Screen results:
- added Rh group to match the LOINC code on the Observation
- corrected antibody screen text result to match the result coding.