### PR TITLE
Code from Condition.category extensible binding is missing in Condition-coronary-syndrome.json

### DIFF
--- a/au-fhir-test-data-set/au-core/Condition-coronary-syndrome.json
+++ b/au-fhir-test-data-set/au-core/Condition-coronary-syndrome.json
@@ -28,6 +28,11 @@
     {
       "coding": [
         {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "problem-list-item",
+          "display": "Problem List Item"
+        },
+        {
           "system": "http://snomed.info/sct",
           "code": "55607006",
           "display": "Problem"


### PR DESCRIPTION
`Condition-coronary-syndrome.json` is missing a Condition.category coding from the extensible binding.
This would be fine, except that the category code is Problem, and by extensible binding rules, is close enough in meaning that the extensibly bound code should also be present. 