### PR TITLE
Removed dose form from Medication examples as the form is inactive

### DIFF
--- a/au-fhir-test-data-set/au-core/Medication-metformin-mp.json
+++ b/au-fhir-test-data-set/au-core/Medication-metformin-mp.json
@@ -14,14 +14,5 @@
         "display": "metformin"
       }
     ]
-  },
-  "form": {
-    "coding": [
-      {
-        "system": "http://snomed.info/sct",
-        "code": "154011000036109",
-        "display": "tablet"
-      }
-    ]
   }
 }

--- a/au-fhir-test-data-set/au-core/Medication-metformin-mpp.json
+++ b/au-fhir-test-data-set/au-core/Medication-metformin-mpp.json
@@ -14,14 +14,5 @@
         "display": "Metformin hydrochloride 500 mg tablet, 100"
       }
     ]
-  },
-  "form": {
-    "coding": [
-      {
-        "system": "http://snomed.info/sct",
-        "code": "154011000036109",
-        "display": "tablet"
-      }
-    ]
   }
 }

--- a/au-fhir-test-data-set/au-core/Medication-metformin-tpp.json
+++ b/au-fhir-test-data-set/au-core/Medication-metformin-tpp.json
@@ -14,14 +14,5 @@
         "display": "Metformin (Apo) 500 mg tablet, 100"
       }
     ]
-  },
-  "form": {
-    "coding": [
-      {
-        "system": "http://snomed.info/sct",
-        "code": "154011000036109",
-        "display": "tablet"
-      }
-    ]
   }
 }

--- a/au-fhir-test-data-set/au-core/Medication-perindopril-amlodipine-mpp.json
+++ b/au-fhir-test-data-set/au-core/Medication-perindopril-amlodipine-mpp.json
@@ -14,14 +14,5 @@
         "display": "Perindopril arginine 10 mg + amlodipine 10 mg tablet, 30"
       }
     ]
-  },
-  "form": {
-    "coding": [
-      {
-        "system": "http://snomed.info/sct",
-        "code": "154011000036109",
-        "display": "tablet"
-      }
-    ]
   }
 }

--- a/au-fhir-test-data-set/au-core/Medication-reaptan-missing-code.json
+++ b/au-fhir-test-data-set/au-core/Medication-reaptan-missing-code.json
@@ -13,14 +13,5 @@
         "code": "unknown"
       }
     ]
-  },
-  "form": {
-    "coding": [
-      {
-        "system": "http://snomed.info/sct",
-        "code": "154011000036109",
-        "display": "tablet"
-      }
-    ]
   }
 }

--- a/au-fhir-test-data-set/au-core/Medication-reaptan-tpp.json
+++ b/au-fhir-test-data-set/au-core/Medication-reaptan-tpp.json
@@ -14,14 +14,5 @@
         "display": "Reaptan 10 mg/10 mg (perindopril arginine/amlodipine) tablet, 30"
       }
     ]
-  },
-  "form": {
-    "coding": [
-      {
-        "system": "http://snomed.info/sct",
-        "code": "154011000036109",
-        "display": "tablet"
-      }
-    ]
   }
 }

--- a/au-fhir-test-data-set/au-core/MedicationRequest-klacid.json
+++ b/au-fhir-test-data-set/au-core/MedicationRequest-klacid.json
@@ -24,16 +24,6 @@
           }
         ],
         "text": "clarithromycin 250 mg tablet, 100"
-      },
-      "form": {
-        "coding": [
-          {
-            "system": "http://snomed.info/sct",
-            "code": "154011000036109",
-            "display": "tablet"
-          }
-        ],
-        "text": "tablet"
       }
     }
   ],

--- a/au-fhir-test-data-set/au-core/MedicationRequest-metformin-contained.json
+++ b/au-fhir-test-data-set/au-core/MedicationRequest-metformin-contained.json
@@ -24,16 +24,6 @@
           }
         ],
         "text": "metformin hydrochloride 500 mg tablet, 100"
-      },
-      "form": {
-        "coding": [
-          {
-            "system": "http://snomed.info/sct",
-            "code": "154011000036109",
-            "display": "tablet"
-          }
-        ],
-        "text": "tablet"
       }
     }
   ],

--- a/au-fhir-test-data-set/au-core/MedicationStatement-inpatient-complete.json
+++ b/au-fhir-test-data-set/au-core/MedicationStatement-inpatient-complete.json
@@ -24,16 +24,6 @@
           }
         ],
         "text": "clarithromycin 250 mg tablet, 100"
-      },
-      "form": {
-        "coding": [
-          {
-            "system": "http://snomed.info/sct",
-            "code": "154011000036109",
-            "display": "tablet"
-          }
-        ],
-        "text": "tablet"
       }
     }
   ],


### PR DESCRIPTION
The Medication.form element is not Must Support. I have removed dose form 'tablet' from Medication examples as `154011000036109 | tablet |` was inactivated in AMT V4. This aligns with the decision made in AU Core, to remove the form element from examples.