### PR TITLE
Restore Bobrester PractitionerRole, Practitioner and Organization examples from AU Core IG

### DIFF
--- a/au-fhir-test-data-set/au-core/Organization-bobrester-medical-center.json
+++ b/au-fhir-test-data-set/au-core/Organization-bobrester-medical-center.json
@@ -1,0 +1,44 @@
+{
+  "resourceType" : "Organization",
+  "id" : "bobrester-medical-center",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization"]
+  },
+  "identifier" : [{
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+        "code" : "ABN"
+      }],
+      "text" : "ABN"
+    },
+    "system" : "http://hl7.org.au/id/abn",
+    "value" : "12345678901"
+  }],
+  "type" : [{
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "288565001",
+      "display" : "Medical centre"
+    }],
+    "text" : "Medical Center"
+  }],
+  "name" : "Bobrester Medical Center",
+  "telecom" : [{
+    "system" : "email",
+    "value" : "info@bobrestermedical.example.com",
+    "use" : "work"
+  },
+  {
+    "system" : "phone",
+    "value" : "(07) 5550 2427",
+    "use" : "work"
+  }],
+  "address" : [{
+    "line" : ["87 Western Esp"],
+    "city" : "Tindal RAAF",
+    "state" : "QLD",
+    "postalCode" : "4655",
+    "country" : "AU"
+  }]
+}

--- a/au-fhir-test-data-set/au-core/Practitioner-bobrester-bob.json
+++ b/au-fhir-test-data-set/au-core/Practitioner-bobrester-bob.json
@@ -1,0 +1,12 @@
+{
+  "resourceType" : "Practitioner",
+  "id" : "bobrester-bob",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner"]
+  },
+  "name" : [{
+    "family" : "Bobrester",
+    "given" : ["Bob"],
+    "prefix" : ["Dr."]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/PractitionerRole-bobrester-bob-gp.json
+++ b/au-fhir-test-data-set/au-core/PractitionerRole-bobrester-bob-gp.json
@@ -1,0 +1,47 @@
+{
+  "resourceType" : "PractitionerRole",
+  "id" : "bobrester-bob-gp",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole"]
+  },
+  "identifier" : [{
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+        "code" : "EI",
+        "display" : "Employee number"
+      }],
+      "text" : "Employee Number"
+    },
+    "system" : "http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/12345678901",
+    "value" : "12345678",
+    "assigner" : {
+      "display" : "Bobrester Medical Center"
+    }
+  }],
+  "practitioner" : {
+    "reference" : "Practitioner/bobrester-bob"
+  },
+  "organization" : {
+    "reference" : "Organization/bobrester-medical-center"
+  },
+  "code" : [{
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "62247001"
+    },
+    {
+      "system" : "http://www.abs.gov.au/ausstats/abs@.nsf/mf/1220.0",
+      "code" : "253111"
+    }],
+    "text" : "General Practitioner"
+  }],
+  "telecom" : [{
+    "system" : "phone",
+    "value" : "0491579760"
+  },
+  {
+    "system" : "email",
+    "value" : "drbob@bobrestermedical.example.com"
+  }]
+}


### PR DESCRIPTION
This PR restores AU Core Practitioner, AU Core PractitionerRole and AU Core Organization IG example resources that were previously removed from the test data repository:
- PractitionerRole/bobrester-bob-gp
- Practitioner/bobrester-bob
- Organization/bobrester-medical-center

These examples have already been reviewed as part of the AU Core IG. The JSON examples are taken from the AU Core IG with the `text` element removed, but are otherwise unchanged.

This PR is prerequisite for adding additional AU Core example resources to the test data repository, as many of those examples reference these resources and rely on them to maintain referential integrity.

