### PR TITLE
Add AU Core Endpoint examples from the IG

### DIFF
--- a/au-fhir-test-data-set/au-core/DiagnosticReport-covid-report.json
+++ b/au-fhir-test-data-set/au-core/DiagnosticReport-covid-report.json
@@ -1,0 +1,67 @@
+{
+  "resourceType" : "DiagnosticReport",
+  "id" : "covid-report",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticreport"]
+  },
+  "identifier" : [{
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+        "code" : "FILL"
+      }]
+    },
+    "system" : "http://ns.electronichealth.net.au/id/hpio-scoped/report/1.0/8003628233373131",
+    "value" : "26-155299-COV-01",
+    "assigner" : {
+      "reference" : "Organization/pullabooka-pathology",
+      "display" : "Pullabooka Pathology"
+    }
+  },
+  {
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+        "code" : "FGN"
+      }]
+    },
+    "system" : "http://ns.electronichealth.net.au/id/hpio-scoped/report/1.0/8003628233373131",
+    "value" : "26-155299-COV-01",
+    "assigner" : {
+      "reference" : "Organization/pullabooka-pathology",
+      "display" : "Pullabooka Pathology"
+    }
+  }],
+  "status" : "final",
+  "category" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/v2-0074",
+      "code" : "LAB",
+      "display" : "Laboratory"
+    }]
+  }],
+  "code" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "1445431000168101",
+      "display" : "SARS-CoV-2 nucleic acid assay"
+    }]
+  },
+  "subject" : {
+    "reference" : "Patient/wang-li"
+  },
+  "effectiveDateTime" : "2021-02-15T12:00:00+10:00",
+  "issued" : "2021-02-16T10:00:00+10:00",
+  "performer" : [{
+    "reference" : "Organization/pullabooka-pathology"
+  }],
+  "result" : [{
+    "reference" : "Observation/pathresult-covid-1",
+    "display" : "Covid-19 PCR"
+  }],
+  "presentedForm" : [{
+    "contentType" : "application/pdf",
+    "url" : "http://example.org.au/fhir/reports/covid-report-123.pdf",
+    "hash" : "d3b07384d113edec49eaa6238ad5ff00"
+  }]
+}

--- a/au-fhir-test-data-set/au-core/DiagnosticReport-lipid-panel-report.json
+++ b/au-fhir-test-data-set/au-core/DiagnosticReport-lipid-panel-report.json
@@ -1,0 +1,74 @@
+{
+  "resourceType" : "DiagnosticReport",
+  "id" : "lipid-panel-report",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticreport"]
+  },
+  "identifier" : [{
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+        "code" : "FILL"
+      }]
+    },
+    "system" : "http://ns.electronichealth.net.au/id/hpio-scoped/report/1.0/8003628233373131",
+    "value" : "26-1552642-HDL-01",
+    "assigner" : {
+      "reference" : "Organization/pullabooka-pathology",
+      "display" : "Pullabooka Pathology"
+    }
+  },
+  {
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+        "code" : "FGN"
+      }]
+    },
+    "system" : "http://ns.electronichealth.net.au/id/hpio-scoped/report/1.0/8003628233373131",
+    "value" : "26-1552642",
+    "assigner" : {
+      "reference" : "Organization/pullabooka-pathology",
+      "display" : "Pullabooka Pathology"
+    }
+  }],
+  "status" : "final",
+  "category" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/v2-0074",
+      "code" : "LAB",
+      "display" : "Laboratory"
+    }]
+  }],
+  "code" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "16254007",
+      "display" : "Lipid panel"
+    }]
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "effectiveDateTime" : "2023-01-17T08:30:00+10:00",
+  "issued" : "2023-01-18T09:30:00+10:00",
+  "performer" : [{
+    "reference" : "Organization/pullabooka-pathology"
+  }],
+  "result" : [{
+    "reference" : "Observation/lipid-hdl-1",
+    "display" : "HDL"
+  },
+  {
+    "reference" : "Observation/lipid-ldl-1",
+    "display" : "LDL"
+  },
+  {
+    "reference" : "Observation/lipid-total-chol-1",
+    "display" : "Total cholesterol"
+  },
+  {
+    "reference" : "Observation/lipid-triglyceride-1",
+    "display" : "Triglyceride"
+  }]
+}


### PR DESCRIPTION
Add Endpoint example resources to demonstrate AU Core Endpoint profile. 

These examples have already been reviewed as part of the AU Core IG. The JSON examples are taken from the AU Core IG with the `text` element removed, but are otherwise unchanged.

These examples are self-contained and do not reference other resources.