### PR TITLE
AU Core Endpoint examples from the IG

### DIFF
--- a/au-fhir-test-data-set/au-core/Endpoint-bobrester-fhir-rest.json
+++ b/au-fhir-test-data-set/au-core/Endpoint-bobrester-fhir-rest.json
@@ -1,0 +1,20 @@
+{
+  "resourceType" : "Endpoint",
+  "id" : "bobrester-fhir-rest",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-endpoint"]
+  },
+  "status" : "active",
+  "connectionType" : {
+    "system" : "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+    "code" : "hl7-fhir-rest"
+  },
+  "name" : "Bobrester Medical Center FHIR Endpoint",
+  "payloadType" : [{
+    "coding" : [{
+      "system" : "http://hl7.org/fhir/resource-types",
+      "code" : "Patient"
+    }]
+  }],
+  "address" : "https://api.bobrestermedical.example.com/fhir/R4"
+}

--- a/au-fhir-test-data-set/au-core/Endpoint-mh-audiology-smd.json
+++ b/au-fhir-test-data-set/au-core/Endpoint-mh-audiology-smd.json
@@ -1,0 +1,26 @@
+{
+  "resourceType" : "Endpoint",
+  "id" : "mh-audiology-smd",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-endpoint"]
+  },
+  "status" : "active",
+  "connectionType" : {
+    "system" : "http://terminology.hl7.org.au/CodeSystem/endpoint-connection-type",
+    "code" : "http://ns.electronichealth.net.au/smd/intf/SealedMessageDelivery/TLS/2010"
+  },
+  "name" : "Mitchell's Hill Audiology Endpoint",
+  "payloadType" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org.au/CodeSystem/endpoint-payload-type",
+      "code" : "http://ns.hl7.org.au/hl7v2/profiles/HL7AU-OO-REF-SIMPLIFIED-201706"
+    }]
+  },
+  {
+    "coding" : [{
+      "system" : "http://terminology.hl7.org.au/CodeSystem/endpoint-payload-type",
+      "code" : "http://ns.electronichealth.net.au/er/sc/deliver/hl7Mdm/2012"
+    }]
+  }],
+  "address" : "https://smd.mitchellshillaudiology.example.com.au/SealedMessageDelivery.svc"
+}

--- a/au-fhir-test-data-set/au-core/Endpoint-murrabit-hospital-hl7-v2-mllp.json
+++ b/au-fhir-test-data-set/au-core/Endpoint-murrabit-hospital-hl7-v2-mllp.json
@@ -1,0 +1,36 @@
+{
+  "resourceType" : "Endpoint",
+  "id" : "murrabit-hospital-hl7-v2-mllp",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-endpoint"]
+  },
+  "status" : "active",
+  "connectionType" : {
+    "system" : "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+    "code" : "hl7v2-mllp",
+    "display" : "HL7 v2 MLLP"
+  },
+  "name" : "Murrabit Hospital HL7 V2 Endpoint",
+  "payloadType" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org.au/CodeSystem/endpoint-payload-type",
+      "code" : "http://ns.electronichealth.net.au/ds/sc/deliver/hl7Mdm/2012",
+      "display" : "HL7 V2 MDM Discharge Summary"
+    }]
+  },
+  {
+    "coding" : [{
+      "system" : "http://terminology.hl7.org.au/CodeSystem/endpoint-payload-type",
+      "code" : "http://ns.electronichealth.net.au/er/sc/deliver/hl7Mdm/2012",
+      "display" : "HL7 V2 MDM eReferral"
+    }]
+  },
+  {
+    "coding" : [{
+      "system" : "http://terminology.hl7.org.au/CodeSystem/endpoint-payload-type",
+      "code" : "http://ns.electronichealth.net.au/es/sc/deliver/hl7Mdm/2012",
+      "display" : "HL7 V2 MDM Event Summary"
+    }]
+  }],
+  "address" : "mllp://hl7v2.murrabithospital.example.com:56123"
+}


### PR DESCRIPTION
Add Endpoint example resources to demonstrate AU Core Endpoint profile.

These examples have already been reviewed as part of the AU Core IG. The JSON examples are taken from the AU Core IG with the text element removed, but are otherwise unchanged.

These examples are self-contained and do not reference other resources.