### PR TITLE
Update AU Core MedicationDispense examples to align with the IG

### DIFF
--- a/au-fhir-test-data-set/au-core/Medication-lipex.json
+++ b/au-fhir-test-data-set/au-core/Medication-lipex.json
@@ -1,0 +1,14 @@
+{
+  "resourceType" : "Medication",
+  "id" : "lipex",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"]
+  },
+  "code" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "6193011000036103",
+      "display" : "Lipex 40 mg tablet"
+    }]
+  }
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-lipex.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-lipex.json
@@ -1,19 +1,19 @@
 {
   "resourceType" : "MedicationDispense",
-  "id" : "simvastatin",
+  "id" : "lipex",
   "meta" : {
     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
   },
   "status" : "completed",
   "medicationReference" : {
-    "reference" : "Medication/simvastatin"
+    "reference" : "Medication/lipex"
   },
   "subject" : {
     "reference" : "Patient/wang-li"
   },
   "performer" : [{
     "actor" : {
-      "display" : "Main Street Pharmacy"
+      "reference" : "Organization/appin-pharmacy"
     }
   }],
   "authorizingPrescription" : [{

--- a/au-fhir-test-data-set/au-core/MedicationDispense-panadeine-forte.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-panadeine-forte.json
@@ -1,6 +1,6 @@
 {
   "resourceType" : "MedicationDispense",
-  "id" : "paracetamol-codeine",
+  "id" : "panadeine-forte",
   "meta" : {
     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
   },
@@ -8,8 +8,12 @@
   "medicationCodeableConcept" : {
     "coding" : [{
       "system" : "http://snomed.info/sct",
-      "code" : "79115011000036100",
-      "display" : "Paracetamol 500 mg + codeine phosphate hemihydrate 30 mg tablet"
+      "code" : "835831000168109",
+      "display" : "Panadeine Forte tablet"
+    },
+    {
+      "system" : "http://pbs.gov.au/code/item",
+      "code" : "12022R"
     }]
   },
   "subject" : {
@@ -17,7 +21,7 @@
   },
   "performer" : [{
     "actor" : {
-      "display" : "Main Street Pharmacy"
+      "reference" : "Organization/appin-pharmacy"
     }
   }],
   "authorizingPrescription" : [{
@@ -30,6 +34,9 @@
     "code" : "TAB"
   },
   "whenPrepared" : "2018-07-15",
+  "note" : [{
+    "text" : "Consumer advised not to exceed 8 tablets in 24 hours."
+  }],
   "dosageInstruction" : [{
     "text" : "1-2 tablets every 4-6 hours as needed for pain",
     "timing" : {

--- a/au-fhir-test-data-set/au-core/MedicationDispense-reaptan.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-reaptan.json
@@ -24,7 +24,7 @@
   },
   "performer" : [{
     "actor" : {
-      "display" : "Main Street Pharmacy"
+      "reference" : "PractitionerRole/pharmacist-megan-peterson"
     }
   }],
   "authorizingPrescription" : [{

--- a/au-fhir-test-data-set/au-core/Practitioner-megan-peterson.json
+++ b/au-fhir-test-data-set/au-core/Practitioner-megan-peterson.json
@@ -1,0 +1,24 @@
+{
+  "resourceType" : "Practitioner",
+  "id" : "megan-peterson",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner"]
+  },
+  "identifier" : [{
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+        "code" : "NPI",
+        "display" : "National provider identifier"
+      }],
+      "text" : "HPI-I"
+    },
+    "system" : "http://ns.electronichealth.net.au/id/hi/hpii/1.0",
+    "value" : "8003614900051424"
+  }],
+  "name" : [{
+    "use" : "official",
+    "family" : "Peterson",
+    "given" : ["Megan"]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/PractitionerRole-pharmacist-megan-peterson.json
+++ b/au-fhir-test-data-set/au-core/PractitionerRole-pharmacist-megan-peterson.json
@@ -1,0 +1,41 @@
+{
+  "resourceType" : "PractitionerRole",
+  "id" : "pharmacist-megan-peterson",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole"]
+  },
+  "identifier" : [{
+    "type" : {
+      "coding" : [{
+        "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+        "code" : "UPIN"
+      }],
+      "text" : "Medicare Provider Number"
+    },
+    "system" : "http://ns.electronichealth.net.au/id/medicare-provider-number",
+    "value" : "2448781F"
+  }],
+  "practitioner" : {
+    "reference" : "Practitioner/megan-peterson"
+  },
+  "organization" : {
+    "reference" : "Organization/appin-pharmacy"
+  },
+  "code" : [{
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "46255001",
+      "display" : "Pharmacist"
+    }],
+    "text" : "Pharmacist"
+  }],
+  "telecom" : [{
+    "system" : "phone",
+    "value" : "0255500340"
+  },
+  {
+    "system" : "email",
+    "value" : "megan.peterson@appinpharmacy.example.com.au",
+    "use" : "work"
+  }]
+}


### PR DESCRIPTION
Changes to align AU Core MedicationDispense IG examples with the current AU Core IG.

These examples have already been reviewed as part of the AU Core IG. The JSON examples are taken from the AU Core IG with the `text` element removed, but are otherwise unchanged. 

Changes in this PR:
- Removed MedicationDispense/simvastatin, and replaced with MedicationDispense/lipex
- Removed MedicationDispense/paracetamol-codeine, and replaced with MedicationDispense/panadeine-forte
- Updated MedicatonDispense/reaptan

Referential integrity: 

- All instances of subject are relative references to the following Patient resources:
   - https://github.com/hl7au/au-fhir-test-data/blob/163eaa92fbd356cda20d37b98fee459206d3aa09/au-fhir-test-data-set/au-core/Patient-bennelong-anne.json
   - https://github.com/hl7au/au-fhir-test-data/blob/163eaa92fbd356cda20d37b98fee459206d3aa09/au-fhir-test-data-set/au-core/Patient-wang-li.json
- Instances of authorizingPrescription are relative references to the following MedicatinRequest resources:
  -  https://github.com/hl7au/au-fhir-test-data/blob/16be2619b74065060e35760a49c6a86ea1adb50d/au-fhir-test-data-set/au-core/MedicationRequest-simvastatin.json
  - https://github.com/hl7au/au-fhir-test-data/blob/16be2619b74065060e35760a49c6a86ea1adb50d/au-fhir-test-data-set/au-core/MedicationRequest-paracetamol-codeine.json
  - https://github.com/dbojicic/au-fhir-test-data/blob/16be2619b74065060e35760a49c6a86ea1adb50d/au-fhir-test-data-set/au-core/MedicationRequest-reaptan.json
- Instances of performer are
   - relative references to the following Organization resource: https://github.com/hl7au/au-fhir-test-data/blob/16be2619b74065060e35760a49c6a86ea1adb50d/au-fhir-test-data-set/au-core/Organization-appin-pharmacy.json
   - included in this PR: PractitionerRole/pharmacist-megan-peterson, and Practitioner/megan-peterson

In addition, new Medication example Medication/lipex is added.


