### PR TITLE
Update AU Core Endpoint examples to align with the IG

### DIFF
--- a/au-fhir-test-data-set/au-core/Endpoint-bobrester-fhir-rest.json
+++ b/au-fhir-test-data-set/au-core/Endpoint-bobrester-fhir-rest.json
@@ -12,8 +12,8 @@
   "name" : "Bobrester Medical Center FHIR Endpoint",
   "payloadType" : [{
     "coding" : [{
-      "system" : "http://hl7.org/fhir/resource-types",
-      "code" : "Patient"
+      "system" : "http://terminology.hl7.org/CodeSystem/endpoint-payload-type",
+      "code" : "any"
     }]
   }],
   "address" : "https://api.bobrestermedical.example.com/fhir/R4"

--- a/au-fhir-test-data-set/au-core/Endpoint-hl7au-dev-terminology-fhir-rest.json
+++ b/au-fhir-test-data-set/au-core/Endpoint-hl7au-dev-terminology-fhir-rest.json
@@ -1,0 +1,37 @@
+{
+  "resourceType" : "Endpoint",
+  "id" : "hl7au-dev-terminology-fhir-rest",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-endpoint"]
+  },
+  "extension" : [{
+    "url" : "http://hl7.org/fhir/5.0/StructureDefinition/extension-Endpoint.environmentType",
+    "valueCodeableConcept" : {
+      "coding" : [{
+        "system" : "http://hl7.org/fhir/endpoint-environment",
+        "code" : "dev",
+        "display" : "Development"
+      }]
+    }
+  }],
+  "status" : "active",
+  "connectionType" : {
+    "system" : "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+    "code" : "hl7-fhir-rest",
+    "display" : "HL7 FHIR"
+  },
+  "name" : "HL7 AU Development Terminology Server",
+  "managingOrganization" : {
+    "display" : "HL7 Australia"
+  },
+  "payloadType" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/endpoint-payload-type",
+      "code" : "any",
+      "display" : "Any"
+    }]
+  }],
+  "payloadMimeType" : ["application/fhir+json",
+  "application/fhir+xml"],
+  "address" : "https://tx.dev.hl7.org.au/fhir"
+}

--- a/au-fhir-test-data-set/au-core/Endpoint-mh-audiology-smd.json
+++ b/au-fhir-test-data-set/au-core/Endpoint-mh-audiology-smd.json
@@ -22,5 +22,5 @@
       "code" : "http://ns.electronichealth.net.au/er/sc/deliver/hl7Mdm/2012"
     }]
   }],
-  "address" : "https://smd.mitchellshillaudiology.example.com.au/SealedMessageDelivery.svc"
+  "address" : "https://smd.mitchellshillaudiology.example.com/SealedMessageDelivery.svc"
 }

--- a/au-fhir-test-data-set/au-core/Endpoint-sparked-aucore-fhir-rest.json
+++ b/au-fhir-test-data-set/au-core/Endpoint-sparked-aucore-fhir-rest.json
@@ -1,0 +1,42 @@
+{
+  "resourceType" : "Endpoint",
+  "id" : "sparked-aucore-fhir-rest",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-endpoint"]
+  },
+  "extension" : [{
+    "url" : "http://hl7.org/fhir/5.0/StructureDefinition/extension-Endpoint.environmentType",
+    "valueCodeableConcept" : {
+      "coding" : [{
+        "system" : "http://hl7.org/fhir/endpoint-environment",
+        "code" : "dev",
+        "display" : "Development"
+      }]
+    }
+  }],
+  "status" : "active",
+  "connectionType" : {
+    "system" : "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+    "code" : "hl7-fhir-rest",
+    "display" : "HL7 FHIR"
+  },
+  "name" : "Sparked Development FHIR Server (AU Core)",
+  "managingOrganization" : {
+    "display" : "CSIRO"
+  },
+  "contact" : [{
+    "system" : "url",
+    "value" : "https://chat.fhir.org/#narrow/channel/179173-australia/topic/Sparked.20FHIR.20Server",
+    "use" : "work"
+  }],
+  "payloadType" : [{
+    "coding" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/endpoint-payload-type",
+      "code" : "any",
+      "display" : "Any"
+    }]
+  }],
+  "payloadMimeType" : ["application/fhir+json",
+  "application/fhir+xml"],
+  "address" : "https://smile.sparked-fhir.com/aucore/fhir/DEFAULT"
+}


### PR DESCRIPTION
Changes to align AU Core Endpoint IG examples with the current IG: 
- update Endpoint/bobrester-fhir-rest
- update Endpoint/mh-audiology-smd
- add Endpoint/hl7au-dev-terminology-fhir-rest
- add Endpoint/sparked-aucore-fhir-rest

These examples have already been reviewed as part of the AU Core IG. The JSON examples are taken from the AU Core IG with the `text` element removed, but are otherwise unchanged.

These examples are self-contained and do not reference other resources.