### PR TITLE
Update AU Core and AU PS test data for AU Base identifier changes

### DIFF
--- a/au-fhir-test-data-set/au-core/Organization-adv-hearing-care.json
+++ b/au-fhir-test-data-set/au-core/Organization-adv-hearing-care.json
@@ -11,8 +11,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-alice-springs-medical-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-alice-springs-medical-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-annandale-dental.json
+++ b/au-fhir-test-data-set/au-core/Organization-annandale-dental.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-annie-river-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-annie-river-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-appin-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-appin-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-back-valley-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-back-valley-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-balbarrup-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-balbarrup-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-barney-view-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-barney-view-private-hospital.json
@@ -25,8 +25,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-bayview-heights-oncology-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-bayview-heights-oncology-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-bayview-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-bayview-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-beltana-medical-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-beltana-medical-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-berat-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-berat-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-beswick-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-beswick-private-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-blumont-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-blumont-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-bridgewater-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-bridgewater-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-bucketty-oncology-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-bucketty-oncology-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-bunbury-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-bunbury-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-bungabbee-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-bungabbee-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-calwell-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-calwell-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-canton-beach-physiotherapy.json
+++ b/au-fhir-test-data-set/au-core/Organization-canton-beach-physiotherapy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-cape-jaffa-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-cape-jaffa-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-carrington-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-carrington-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-cooriemungle-cardiology-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-cooriemungle-cardiology-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-cracow-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-cracow-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-cullen-bay-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-cullen-bay-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-douglas-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-douglas-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-dubbo-emergency.json
+++ b/au-fhir-test-data-set/au-core/Organization-dubbo-emergency.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-east-mackay-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-east-mackay-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-east-point-renal-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-east-point-renal-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-edwardstown-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-edwardstown-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-elimbah-medical-centre.json
+++ b/au-fhir-test-data-set/au-core/Organization-elimbah-medical-centre.json
@@ -25,8 +25,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-eltham-north-optical.json
+++ b/au-fhir-test-data-set/au-core/Organization-eltham-north-optical.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-fishermans-reach-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-fishermans-reach-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-frenchs-forest-east-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-frenchs-forest-east-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-gangat-endocrinology-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-gangat-endocrinology-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-ginninderra-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-ginninderra-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-glennie-heights-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-glennie-heights-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-higher-macdonald-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-higher-macdonald-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-hudson-aged-care.json
+++ b/au-fhir-test-data-set/au-core/Organization-hudson-aged-care.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-joyces-creek-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-joyces-creek-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-kaltukatjara-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-kaltukatjara-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-karkoo-chiropractic.json
+++ b/au-fhir-test-data-set/au-core/Organization-karkoo-chiropractic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-kensington-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-kensington-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-kioma-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-kioma-pathology.json
@@ -25,8 +25,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-kippenduff-cardiologist.json
+++ b/au-fhir-test-data-set/au-core/Organization-kippenduff-cardiologist.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-koolanooka-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-koolanooka-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-kununurra-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-kununurra-pathology.json
@@ -25,8 +25,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-lake-wells-medical-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-lake-wells-medical-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-launceston-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-launceston-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-launching-place-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-launching-place-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-leasingham-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-leasingham-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-lilydale-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-lilydale-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-loch-lomond-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-loch-lomond-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-ludmilla-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-ludmilla-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-mcbeath-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-mcbeath-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-mckenzie-creek-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-mckenzie-creek-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-milnes-bridge-medical-centre.json
+++ b/au-fhir-test-data-set/au-core/Organization-milnes-bridge-medical-centre.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-missing-name.json
+++ b/au-fhir-test-data-set/au-core/Organization-missing-name.json
@@ -11,8 +11,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-mitchells-hill-audiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-mitchells-hill-audiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-monash-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-monash-private-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-morgantown-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-morgantown-private-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-mossy-point-medical-centre.json
+++ b/au-fhir-test-data-set/au-core/Organization-mossy-point-medical-centre.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-mount-charlton-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-mount-charlton-radiology.json
@@ -25,8 +25,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-mount-glasgow-emergency.json
+++ b/au-fhir-test-data-set/au-core/Organization-mount-glasgow-emergency.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-mount-mitchell-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-mount-mitchell-private-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-murrabit-public-hopsital.json
+++ b/au-fhir-test-data-set/au-core/Organization-murrabit-public-hopsital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-ngunnawal-medical-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-ngunnawal-medical-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-nicholls-radiology.json
+++ b/au-fhir-test-data-set/au-core/Organization-nicholls-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-oxley-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-oxley-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-piesseville-gastroenterology.json
+++ b/au-fhir-test-data-set/au-core/Organization-piesseville-gastroenterology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-pine-creek-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-pine-creek-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-pine-view-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/Organization-pine-view-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-pullabooka-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-pullabooka-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-quinninup-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/Organization-quinninup-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-robigana-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-robigana-private-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-rosetta-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-rosetta-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-rowsley-aged-care.json
+++ b/au-fhir-test-data-set/au-core/Organization-rowsley-aged-care.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-southedge-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-southedge-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-southport-medical-practice.json
+++ b/au-fhir-test-data-set/au-core/Organization-southport-medical-practice.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-tarampa-emergency.json
+++ b/au-fhir-test-data-set/au-core/Organization-tarampa-emergency.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system": "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code": "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-trentham-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-trentham-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-verona-sands-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-verona-sands-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-wallendbeen-aged-care.json
+++ b/au-fhir-test-data-set/au-core/Organization-wallendbeen-aged-care.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-wannon-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-wannon-private-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-wingfield-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-wingfield-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-woodcroft-pathology.json
+++ b/au-fhir-test-data-set/au-core/Organization-woodcroft-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/Organization-yunta-private-hospital.json
+++ b/au-fhir-test-data-set/au-core/Organization-yunta-private-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-cardiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-cardiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-endocrinology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-endocrinology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-medical-centre.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-medical-centre.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-nephrology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-nephrology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-ophthalmology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-ophthalmology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-optical.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-optical.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-pathology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-physiotherapy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-physiotherapy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-radiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM scenario - Drafted/Organization-sunshine-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-adelaide-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-adelaide-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-royal-park-medical-centre.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-royal-park-medical-centre.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-semaphore-aged-care.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-semaphore-aged-care.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-cardiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-cardiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-dental.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-dental.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-dietitian-service.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-dietitian-service.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-ot-services.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-ot-services.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-pathology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-podiatry.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-podiatry.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-radiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/CCM_Aged care scenario - Future/Organization-woodville-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-community-health.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-community-health.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-nutrition.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-nutrition.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-optometry.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-optometry.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-ot-services.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-ot-services.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-physiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-physiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-physiotherapy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-physiotherapy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-podiatry.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-podiatry.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-psychology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-psychology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-specialist-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/FIrst nations scenario/Organization-broome-specialist-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-community-health.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-community-health.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-dental.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-dental.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-midwifery.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-midwifery.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-nutrition.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-nutrition.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-specialist-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-parramatta-specialist-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-optical.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-optical.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-ot-services.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-ot-services.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-pathology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-physiotherapy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-physiotherapy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-radiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-specialist-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Family scenario w baby (2 month old)/Organization-westmead-specialist-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-cardiology-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-cardiology-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-dental.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-dental.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-nephrology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-nephrology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-nutrition.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-nutrition.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-ophthalmology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-ophthalmology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-optical.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-optical.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-ot-services.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-ot-services.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-pathology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-physiotherapy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-physiotherapy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-radiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-garran-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-manuka-medical-centre.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Paeds scenario (5yo)/Organization-manuka-medical-centre.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-camooweal-community-health.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-camooweal-community-health.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-camooweal-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-camooweal-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-herston-pathology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-herston-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-herston-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-herston-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-herston-radiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-herston-radiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-community-health.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-community-health.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-dental.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-dental.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-ot-services.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-ot-services.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-pathology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-pharmacy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-pharmacy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-physiotherapy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-physiotherapy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-psychology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-psychology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-specialist-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-mt-isa-specialist-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-townsville-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-townsville-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-townsville-public-hospital.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-townsville-public-hospital.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-townsville-specialist-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Rural & remote scenario/Organization-townsville-specialist-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-melbourne-specialist-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-melbourne-specialist-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-southbank-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-southbank-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-southbank-specialist-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-southbank-specialist-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+           "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-southbank-speech-pathology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-southbank-speech-pathology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-medical-clinic.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-medical-clinic.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-ot-services.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-ot-services.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-physiology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-physiology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-physiotherapy.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-physiotherapy.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-psychology.json
+++ b/au-fhir-test-data-set/au-core/consumer-journey/Young adult_adolescent scenario (19-20 yo)/Organization-st-kilda-psychology.json
@@ -24,8 +24,8 @@
       "type": {
         "coding": [
           {
-            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code": "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }
         ],
         "text": "ABN"

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-basicsummary-missing-comp-elements.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-basicsummary-missing-comp-elements.json
@@ -234,8 +234,8 @@
       "identifier" : [{
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-basicsummary.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-basicsummary.json
@@ -216,8 +216,8 @@
       "identifier" : [{
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-basicsummarywihpath.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-basicsummarywihpath.json
@@ -245,8 +245,8 @@
       "identifier" : [{
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-gpvisit-retrieval.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-gpvisit-retrieval.json
@@ -1967,8 +1967,8 @@
       {
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },
@@ -2033,8 +2033,8 @@
       {
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-noknownx.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-noknownx.json
@@ -197,8 +197,8 @@
       {
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-referral-endoconsult-autogen.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-referral-endoconsult-autogen.json
@@ -1192,8 +1192,8 @@
       {
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-referral-endoconsult-curated.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-referral-endoconsult-curated.json
@@ -772,8 +772,8 @@
       {
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },

--- a/au-fhir-test-data-set/au-patient-summary/Bundle-aups-section-emptyreason.json
+++ b/au-fhir-test-data-set/au-patient-summary/Bundle-aups-section-emptyreason.json
@@ -259,8 +259,8 @@
       {
         "type" : {
           "coding" : [{
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
+            "system" : "http://terminology.hl7.org.au/CodeSystem/v2-0203",
+            "code" : "ABN"
           }],
           "text" : "ABN"
         },


### PR DESCRIPTION
Update AU Core and AU PS test data to align with identifier changes introduced in AU Base and included in the August 2026 AU Base R7 ballot publication affecting the representation of: 
- AU PAI-O Identifier
- Australian Business Number (ABN)
- Australian Company Number (ACN)
- Australian Registered Body Number (ARBN).

