### PR TITLE
Add AU Core MedicationDispense test data

### DIFF
--- a/au-fhir-test-data-set/au-core/Medication-atorvastatin.json
+++ b/au-fhir-test-data-set/au-core/Medication-atorvastatin.json
@@ -1,0 +1,14 @@
+{
+  "resourceType" : "Medication",
+  "id" : "atorvastatin",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"]
+  },
+  "code" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "27437011000036101",
+      "display" : "Atorvastatin 20 mg tablet, 30"
+    }]
+  }
+}

--- a/au-fhir-test-data-set/au-core/Medication-simvastatin-pbs.json
+++ b/au-fhir-test-data-set/au-core/Medication-simvastatin-pbs.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "Medication",
+  "id": "simvastatin-pbs",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"
+    ]
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "http://pbs.gov.au/code/item",
+        "code": "8173E",
+        "display": "simvastatin 40 mg tablet, 30"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "28213011000036109",
+        "display": "Simvastatin 40 mg tablet, 30"
+      }
+    ],
+    "text": "Simvastatin 40 mg tablet, 30 tablets"
+  }
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-atorvastatin.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-atorvastatin.json
@@ -5,12 +5,8 @@
     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
   },
   "status" : "completed",
-  "medicationCodeableConcept" : {
-    "coding" : [{
-      "system" : "http://snomed.info/sct",
-      "code" : "27437011000036101",
-      "display" : "Atorvastatin 20 mg tablet, 30"
-    }]
+  "medicationReference" : {
+    "reference" : "Medication/atorvastatin"
   },
   "subject" : {
     "reference" : "Patient/howe-deangelo"

--- a/au-fhir-test-data-set/au-core/MedicationDispense-atorvastatin.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-atorvastatin.json
@@ -1,0 +1,58 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "atorvastatin",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "27437011000036101",
+      "display" : "Atorvastatin 20 mg tablet, 30"
+    }]
+  },
+  "subject" : {
+    "reference" : "Patient/howe-deangelo"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "PractitionerRole/pharmacist-megan-peterson"
+    }
+  }],
+  "authorizingPrescription" : [{
+    "reference" : "MedicationRequest/atorvastatin"
+  }],
+  "quantity" : {
+    "value" : 30,
+    "unit" : "tablet",
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+    "code" : "TAB"
+  },
+  "whenPrepared" : "2021-09-26",
+  "dosageInstruction" : [{
+    "text" : "1 tablet daily",
+    "timing" : {
+      "repeat" : {
+        "frequency" : 1,
+        "period" : 1,
+        "periodUnit" : "d"
+      }
+    },
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "26643006",
+        "display" : "Oral route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 1,
+        "unit" : "TAB",
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+        "code" : "TAB"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-bactrim.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-bactrim.json
@@ -1,0 +1,28 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "bactrim",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "in-progress",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "6632011000036102",
+      "display" : "Bactrim DS tablet"
+    },
+    {
+      "system" : "http://pbs.gov.au/code/item",
+      "code" : "2951H"
+    }],
+    "text" : "Bactrim DS tablet"
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "PractitionerRole/retailpharmacist-ford-dean"
+    }
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-bisoprolol.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-bisoprolol.json
@@ -1,0 +1,61 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "bisoprolol",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "23281011000036106",
+      "display" : "Bisoprolol fumarate 2.5 mg tablet"
+    }],
+    "text" : "Bisoprolol 2.5mg tab"
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne",
+    "display" : "Mia Leanne Banks"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "Organization/appin-pharmacy",
+      "display" : "Appin Pharmacy"
+    }
+  }],
+  "quantity" : {
+    "value" : 30,
+    "unit" : "tablet",
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+    "code" : "TAB"
+  },
+  "whenPrepared" : "2019-02-05",
+  "note" : [{
+    "text" : "Consumer medicines information provided."
+  }],
+  "dosageInstruction" : [{
+    "text" : "Take half a tablet by mouth every morning.",
+    "timing" : {
+      "repeat" : {
+        "frequency" : 1,
+        "period" : 1,
+        "periodUnit" : "d"
+      }
+    },
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "26643006",
+        "display" : "Oral route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 0.5,
+        "unit" : "tablet",
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+        "code" : "TAB"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-diflucan.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-diflucan.json
@@ -1,0 +1,64 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "diflucan",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "extension" : [{
+        "url" : "http://hl7.org.au/fhir/StructureDefinition/medication-type",
+        "valueCoding" : {
+          "system" : "http://terminology.hl7.org.au/CodeSystem/medication-type",
+          "code" : "BPDSF",
+          "display" : "Branded product with strengths and form"
+        }
+      }],
+      "system" : "http://snomed.info/sct",
+      "code" : "5232011000036102",
+      "display" : "Diflucan 200 mg/100 mL injection, 100 mL vial"
+    }]
+  },
+  "subject" : {
+    "reference" : "Patient/banks-mia-leanne"
+  },
+  "quantity" : {
+    "value" : 1,
+    "unit" : "vial"
+  },
+  "whenPrepared" : "2018-06-25",
+  "whenHandedOver" : "2018-06-25",
+  "note" : [{
+    "text" : "Medicine supplied for intravenous administration."
+  }],
+  "dosageInstruction" : [{
+    "text" : "Every 1-10 days at 10am for 30 minutes",
+    "timing" : {
+      "repeat" : {
+        "duration" : 30,
+        "durationUnit" : "min",
+        "frequency" : 1,
+        "period" : 1,
+        "periodMax" : 10,
+        "periodUnit" : "d",
+        "timeOfDay" : ["10:00:00"]
+      }
+    },
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "47625008",
+        "display" : "Intravenous route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 200,
+        "unit" : "mg",
+        "system" : "http://unitsofmeasure.org",
+        "code" : "mg"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-flucloxacillin.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-flucloxacillin.json
@@ -13,8 +13,7 @@
   },
   "performer" : [{
     "actor" : {
-      "reference" : "Organization/community-pharmacy-example",
-      "display" : "Example Community Pharmacy"
+      "reference" : "Organization/appin-pharmacy"
     }
   }],
   "authorizingPrescription" : [{

--- a/au-fhir-test-data-set/au-core/MedicationDispense-flucloxacillin.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-flucloxacillin.json
@@ -1,0 +1,56 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "flucloxacillin",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "text" : "flucloxacillin 500mg capsule"
+  },
+  "subject" : {
+    "reference" : "Patient/baratz-toni"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "Organization/community-pharmacy-example",
+      "display" : "Example Community Pharmacy"
+    }
+  }],
+  "authorizingPrescription" : [{
+    "reference" : "MedicationRequest/fluclox"
+  }],
+  "quantity" : {
+    "value" : 24,
+    "unit" : "capsule",
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+    "code" : "CAP"
+  },
+  "whenPrepared" : "2022-02-10T15:00:00+10:00",
+  "whenHandedOver" : "2022-02-10T15:15:00+10:00",
+  "dosageInstruction" : [{
+    "text" : "1 capsule every 6 hours for 5 days",
+    "timing" : {
+      "repeat" : {
+        "frequency" : 1,
+        "period" : 6,
+        "periodUnit" : "h"
+      }
+    },
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "26643006",
+        "display" : "Oral route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 1,
+        "unit" : "capsule",
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+        "code" : "CAP"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-flucloxacillin.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-flucloxacillin.json
@@ -4,9 +4,24 @@
   "meta" : {
     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
   },
+  "contained" : [{
+    "resourceType" : "Medication",
+    "id" : "med1",
+    "meta" : {
+     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"]
+     },
+    "code" : {
+     "coding" : [{
+       "system" : "http://snomed.info/sct",
+       "code" : "712541000168104",
+       "display" : "Flucloxacillin (Apo) 500 mg capsule, 24"
+     }],
+     "text" : "Flucloxacillin 500 mg capsule"
+     }
+   }],
   "status" : "completed",
-  "medicationCodeableConcept" : {
-    "text" : "flucloxacillin 500mg capsule"
+  "medicationReference" : {
+    "reference" : "#med1"
   },
   "subject" : {
     "reference" : "Patient/baratz-toni"

--- a/au-fhir-test-data-set/au-core/MedicationDispense-klacid.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-klacid.json
@@ -4,24 +4,13 @@
   "meta" : {
     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
   },
-  "contained" : [{
-    "resourceType" : "Medication",
-    "id" : "med1",
-    "meta" : {
-      "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"]
-    },
-    "code" : {
-      "coding" : [{
-        "system" : "http://snomed.info/sct",
-        "code" : "27908011000036108",
-        "display" : "Clarithromycin 250 mg tablet, 100"
-      }],
-      "text" : "clarithromycin 250 mg tablet, 100"
-    }
-  }],
   "status" : "completed",
-  "medicationReference" : {
-    "reference" : "#med1"
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "27908011000036108",
+      "display" : "Clarithromycin 250 mg tablet, 100"
+    }]
   },
   "subject" : {
     "reference" : "Patient/irvine-ronny-lawrence"

--- a/au-fhir-test-data-set/au-core/MedicationDispense-klacid.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-klacid.json
@@ -1,0 +1,61 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "klacid",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "27908011000036108",
+      "display" : "Clarithromycin 250 mg tablet, 100"
+    }],
+    "text" : "clarithromycin 250 mg tablet, 100"
+  },
+  "subject" : {
+    "reference" : "Patient/irvine-ronny-lawrence"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "Organization/appin-pharmacy"
+    }
+  }],
+  "authorizingPrescription" : [{
+    "reference" : "MedicationRequest/klacid"
+  }],
+  "quantity" : {
+    "value" : 100,
+    "unit" : "TAB",
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+    "code" : "TAB"
+  },
+  "whenPrepared" : "2023-02-20",
+  "whenHandedOver" : "2023-02-20",
+  "dosageInstruction" : [{
+    "text" : "1 Twice a Day\nBefore meals",
+    "timing" : {
+      "repeat" : {
+        "frequency" : 2,
+        "period" : 1,
+        "periodUnit" : "d"
+      }
+    },
+    "asNeededBoolean" : false,
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "26643006",
+        "display" : "Oral route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 1,
+        "unit" : "TAB",
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+        "code" : "TAB"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-klacid.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-klacid.json
@@ -4,14 +4,24 @@
   "meta" : {
     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
   },
+  "contained" : [{
+    "resourceType" : "Medication",
+    "id" : "med1",
+    "meta" : {
+      "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"]
+    },
+    "code" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "27908011000036108",
+        "display" : "Clarithromycin 250 mg tablet, 100"
+      }],
+      "text" : "clarithromycin 250 mg tablet, 100"
+    }
+  }],
   "status" : "completed",
-  "medicationCodeableConcept" : {
-    "coding" : [{
-      "system" : "http://snomed.info/sct",
-      "code" : "27908011000036108",
-      "display" : "Clarithromycin 250 mg tablet, 100"
-    }],
-    "text" : "clarithromycin 250 mg tablet, 100"
+  "medicationReference" : {
+    "reference" : "#med1"
   },
   "subject" : {
     "reference" : "Patient/irvine-ronny-lawrence"

--- a/au-fhir-test-data-set/au-core/MedicationDispense-panadeine-forte-tablet.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-panadeine-forte-tablet.json
@@ -21,9 +21,6 @@
       "reference" : "Organization/mcbeath-pharmacy"
     }
   }],
-  "authorizingPrescription" : [{
-    "reference" : "MedicationRequest/paracetamol-codeine"
-  }],
   "quantity" : {
     "value" : 20,
     "unit" : "TAB",

--- a/au-fhir-test-data-set/au-core/MedicationDispense-panadeine-forte-tablet.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-panadeine-forte-tablet.json
@@ -1,0 +1,65 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "panadeine-forte-tablet",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "835831000168109",
+      "display" : "Panadeine Forte tablet"
+    }],
+    "text" : "Panadeine Forte tablet"
+  },
+  "subject" : {
+    "reference" : "Patient/baratz-toni"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "Organization/mcbeath-pharmacy"
+    }
+  }],
+  "authorizingPrescription" : [{
+    "reference" : "MedicationRequest/paracetamol-codeine"
+  }],
+  "quantity" : {
+    "value" : 20,
+    "unit" : "TAB",
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+    "code" : "TAB"
+  },
+  "whenPrepared" : "2018-07-15",
+  "note" : [{
+    "text" : "Consumer advised not to exceed 8 tablets in 24 hours."
+  }],
+  "dosageInstruction" : [{
+    "text" : "1-2 tablets every 4-6 hours as needed for pain",
+    "timing" : {
+      "repeat" : {
+        "frequency" : 1,
+        "frequencyMax" : 2,
+        "period" : 4,
+        "periodMax" : 6,
+        "periodUnit" : "h"
+      }
+    },
+    "asNeededBoolean" : true,
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "26643006",
+        "display" : "Oral route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 1,
+        "unit" : "TAB",
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+        "code" : "TAB"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-simvastatin-pbs.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-simvastatin-pbs.json
@@ -1,0 +1,63 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "simvastatin-pbs",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://pbs.gov.au/code/item",
+      "code" : "8173E",
+      "display" : "simvastatin 40 mg tablet, 30"
+    },
+    {
+      "system" : "http://snomed.info/sct",
+      "code" : "28213011000036109",
+      "display" : "Simvastatin 40 mg tablet, 30"
+    }],
+    "text" : "Simvastatin 40 mg tablet, 30 tablets"
+  },
+  "subject" : {
+    "reference" : "Patient/hayes-arianne"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "Organization/appin-pharmacy"
+    }
+  }],
+  "authorizingPrescription" : [{
+    "reference" : "MedicationRequest/simvastatin-pbs"
+  }],
+  "quantity" : {
+    "value" : 30,
+    "unit" : "tablet"
+  },
+  "whenPrepared" : "2020-01-15",
+  "note" : [{
+    "text" : "Advised to avoid grapefruit juice due to potential interaction."
+  }],
+  "dosageInstruction" : [{
+    "text" : "Take one tablet daily",
+    "timing" : {
+      "repeat" : {
+        "frequency" : 1,
+        "period" : 1,
+        "periodUnit" : "d"
+      }
+    },
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "26643006",
+        "display" : "Oral route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 40,
+        "unit" : "mg"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-simvastatin-pbs.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-simvastatin-pbs.json
@@ -5,18 +5,8 @@
     "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
   },
   "status" : "completed",
-  "medicationCodeableConcept" : {
-    "coding" : [{
-      "system" : "http://pbs.gov.au/code/item",
-      "code" : "8173E",
-      "display" : "simvastatin 40 mg tablet, 30"
-    },
-    {
-      "system" : "http://snomed.info/sct",
-      "code" : "28213011000036109",
-      "display" : "Simvastatin 40 mg tablet, 30"
-    }],
-    "text" : "Simvastatin 40 mg tablet, 30 tablets"
+  "medicationReference" : {
+    "reference" : "Medication/simvastatin-pbs"
   },
   "subject" : {
     "reference" : "Patient/hayes-arianne"

--- a/au-fhir-test-data-set/au-core/MedicationDispense-ventolin.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-ventolin.json
@@ -35,8 +35,8 @@
     "route" : {
       "coding" : [{
         "system" : "http://snomed.info/sct",
-        "code" : "18679011000036104",
-        "display" : "Inhalation route"
+        "code" : "447694001",
+        "display" : "Respiratory tract route"
       }]
     },
     "doseAndRate" : [{

--- a/au-fhir-test-data-set/au-core/MedicationDispense-ventolin.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-ventolin.json
@@ -1,0 +1,55 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "ventolin",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "13029011000036109",
+      "display" : "Ventolin Inhaler CFC-Free 100 microgram/actuation inhalation, 200 actuations"
+    }]
+  },
+  "subject" : {
+    "reference" : "Patient/italia-sofia"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "Organization/appin-pharmacy",
+      "display" : "Appin Pharmacy"
+    }
+  }],
+  "quantity" : {
+    "value" : 1,
+    "unit" : "inhaler"
+  },
+  "whenHandedOver" : "2024-05-16",
+  "note" : [{
+    "text" : "Consumer medicine information supplied."
+  }],
+  "dosageInstruction" : [{
+    "text" : "Inhale 1-2 puffs when required for wheeze or shortness of breath.",
+    "asNeededBoolean" : true,
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "18679011000036104",
+        "display" : "Inhalation route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseRange" : {
+        "low" : {
+          "value" : 1,
+          "unit" : "puff"
+        },
+        "high" : {
+          "value" : 2,
+          "unit" : "puff"
+        }
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-vitamin-d-drops.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-vitamin-d-drops.json
@@ -1,0 +1,51 @@
+{
+  "resourceType" : "MedicationDispense",
+  "id" : "vitamin-d-drops",
+  "meta" : {
+    "profile" : ["http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"]
+  },
+  "status" : "completed",
+  "medicationCodeableConcept" : {
+    "text" : "Vitamin D oral drops 400 IU/mL"
+  },
+  "subject" : {
+    "reference" : "Patient/baby-banks-john",
+    "display" : "Baby John Banks"
+  },
+  "performer" : [{
+    "actor" : {
+      "reference" : "Organization/appin-pharmacy",
+      "display" : "Appin Pharmacy"
+    }
+  }],
+  "quantity" : {
+    "value" : 1,
+    "unit" : "bottle"
+  },
+  "whenPrepared" : "2023-08-14",
+  "dosageInstruction" : [{
+    "text" : "Give 0.2 mL by mouth once daily.",
+    "timing" : {
+      "repeat" : {
+        "frequency" : 1,
+        "period" : 1,
+        "periodUnit" : "d"
+      }
+    },
+    "route" : {
+      "coding" : [{
+        "system" : "http://snomed.info/sct",
+        "code" : "26643006",
+        "display" : "Oral route"
+      }]
+    },
+    "doseAndRate" : [{
+      "doseQuantity" : {
+        "value" : 0.2,
+        "unit" : "mL",
+        "system" : "http://unitsofmeasure.org",
+        "code" : "mL"
+      }
+    }]
+  }]
+}

--- a/au-fhir-test-data-set/au-core/MedicationDispense-vitamin-d-drops.json
+++ b/au-fhir-test-data-set/au-core/MedicationDispense-vitamin-d-drops.json
@@ -24,28 +24,6 @@
   },
   "whenPrepared" : "2023-08-14",
   "dosageInstruction" : [{
-    "text" : "Give 0.2 mL by mouth once daily.",
-    "timing" : {
-      "repeat" : {
-        "frequency" : 1,
-        "period" : 1,
-        "periodUnit" : "d"
-      }
-    },
-    "route" : {
-      "coding" : [{
-        "system" : "http://snomed.info/sct",
-        "code" : "26643006",
-        "display" : "Oral route"
-      }]
-    },
-    "doseAndRate" : [{
-      "doseQuantity" : {
-        "value" : 0.2,
-        "unit" : "mL",
-        "system" : "http://unitsofmeasure.org",
-        "code" : "mL"
-      }
-    }]
+    "text" : "Give 0.2 mL by mouth once daily."
   }]
 }


### PR DESCRIPTION
Add AU Core MedicationDispense examples for AU Core Inferno. The set of examples is provided to a patient of interest for Inferno: baratz-toni, irvine-ronny-lawrence, italia-sofia, howe-deangelo, hayes-arianne, baby-banks-john, and banks-mia-leanne.

The test data provides:
- at least one MedicationDispense for each AU Core patient used for Inferno testing
- coverage of _Must Support_ elements and different representations, including `CodeableConcept`, referenced `Medication`, and contained `Medication`
- examples of optional elements in addition to _Must Support_ elements (e.g. `whenHandedOver`), providing broader coverage of valid AU Core MedicationDispense content
- examples with and without `authorizingPrescription`, where appropriate, and referencing existing MedicationRequest resources
- `performer` variation, referencing Organization and PractitionerRole
- a mix of coded and text only representation for medication and dosage information