### PR TITLE
Add AU Core Medication instances with ingredient-strength extension

### DIFF
--- a/au-fhir-test-data-set/au-core/Medication-omeprazole-suspension-extemp.json
+++ b/au-fhir-test-data-set/au-core/Medication-omeprazole-suspension-extemp.json
@@ -1,0 +1,77 @@
+{
+  "resourceType": "Medication",
+  "id": "omeprazole-suspension-extemp",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"
+    ]
+  },
+  "code": {
+    "text": "omeprazole 2mg/mL oral suspension, 100mL (extemporaneous)"
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385024007",
+        "display": "Oral suspension"
+      }
+    ]
+  },
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "75861000036107",
+            "display": "Omeprazole 20 mg enteric capsule"
+          }
+        ]
+      },
+      "isActive": true,
+      "strength": {
+        "numerator": {
+          "value": 2,
+          "unit": "mg",
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 1,
+          "unit": "mL",
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    },
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "69930011000036101",
+            "display": "Sodium bicarbonate 8.4% (8.4 g/100 mL) injection, vial"
+          }
+        ]
+      },
+      "strength": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-Medication.ingredient.strength",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/CodeSystem/medication-ingredientstrength",
+                  "code": "qs",
+                  "display": "QS"
+                }
+              ],
+              "text": "q.s. to 100 mL"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/au-fhir-test-data-set/au-core/Medication-pramin.json
+++ b/au-fhir-test-data-set/au-core/Medication-pramin.json
@@ -1,0 +1,116 @@
+{
+  "resourceType": "Medication",
+  "id": "pramin",
+  "meta": {
+    "profile": [
+      "http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"
+    ]
+  },
+  "code": {
+    "coding": [
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org.au/fhir/StructureDefinition/medication-type",
+            "valueCoding": {
+              "system": "http://terminology.hl7.org.au/CodeSystem/medication-type",
+              "code": "UPD",
+              "display": "Unbranded product with no strengths or form"
+            }
+          }
+        ],
+        "system": "http://snomed.info/sct",
+        "code": "56549003",
+        "display": "Metoclopramide"
+      },      
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org.au/fhir/StructureDefinition/medication-type",
+            "valueCoding": {
+              "system": "http://terminology.hl7.org.au/CodeSystem/medication-type",
+              "code": "BPD",
+              "display": "Branded product with no strengths or form"
+            }
+          }
+        ],
+        "system": "http://snomed.info/sct",
+        "code": "3330011000036102",
+        "display": "Pramin"
+      }
+    ]
+  },
+  "manufacturer": {
+    "identifier": {
+      "system": "http://pbs.gov.au/code/manufacturer",
+      "value": "AF"
+    }
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "421026006",
+        "display": "Tablet"
+      }
+    ],
+    "text": "Tablet"
+  },
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "372776000",
+            "display": "Metoclopramide"
+          }
+        ],
+        "text": "metoclopramide"
+      },
+      "isActive": true,
+      "strength": {
+        "numerator": {
+          "value": 10,
+          "unit": "mg",
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 1,
+          "unit": "tablet",
+          "system": "http://unitsofmeasure.org",
+          "code": "{tbl}"
+        }
+      }
+    },
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "51963001",
+            "display": "Sulphites"
+          }
+        ]
+      },
+      "isActive": false,
+      "strength": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-Medication.ingredient.strength",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/CodeSystem/medication-ingredientstrength",
+                  "code": "trace",
+                  "display": "Trace"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Add AU Core Medication instances illustrating the ingredient-strength cross-version extension

## Summary

Adds two new FHIR Medication instances to `au-fhir-test-data-set/au-core/`:

- **`Medication-pramin.json`** — Pramin (metoclopramide) 10 mg tablet, representing a trade product with:
  - a quantifiable active-ingredient strength using the native [`Ratio`](https://hl7.org/fhir/R4/datatypes.html#Ratio) datatype; and
  - a non-quantifiable, trace quantity of sulfites (an excipient that may cause adverse reactions in susceptible individuals), represented using the R5→R4 extension [`ExtensionMedication_Ingredient_Strength`](https://hl7.org/fhir/uv/xver-r5.r4/0.1.0/StructureDefinition-ext-R5-Medication.ing.strength.html). Referenced [Pramin PI](https://www.ebs.tga.gov.au/ebs/picmi/picmirepository.nsf/pdf?OpenAgent&id=CP-2010-PI-05085-3).

  This demonstrates the [guidance](https://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-medication.html#usage-notes):
  > "When representing medication ingredient strength use the native FHIR element `Medication.ingredient.strength` as `Ratio` whenever possible. If the strength cannot be represented as a `Ratio`, it can be represented as `CodeableConcept` (text and/or coding) or `Quantity` using the R5 to R4 pre-adoption extension `ExtensionMedication_Ingredient_Strength`."

- **`Medication-omeprazole-suspension-extemp.json`** — an extemporaneously compounded omeprazole 2 mg/mL oral suspension. This follows the specific [AU Core Medicine Information guidance](https://build.fhir.org/ig/hl7au/au-fhir-core/medicine-information.html) for extemporaneous medications, including a text-only `Medication.code`. Ingredients are represented as being sourced from manufactured products (omeprazole capsules and a sodium bicarbonate injection), with sodium bicarbonate represented using a `q.s.` ("as much as is sufficient.") strength via the same [extension](https://hl7.org/fhir/uv/xver-r5.r4/0.1.0/StructureDefinition-ext-R5-Medication.ing.strength.html). The typical extemporaneous omeprazole formula specifies that sodium bicarbonate solution is added "q.s. to the final volume". The sodium bicarbonate injection is intentionally used as the vehicle/diluent in preparation of the oral suspension (a known practice in hospital pharmacy).

## Motivation

The existing BenPen example on the [AU Core Medicine Information page](https://build.fhir.org/ig/hl7au/au-fhir-core/medicine-information.html) uses the [`ExtensionMedication_Ingredient_Strength`](https://hl7.org/fhir/uv/xver-r5.r4/0.1.0/StructureDefinition-ext-R5-Medication.ing.strength.html) with coding "QS" ("as much as is sufficient."), which doesn't quite fit an ingredient of known strength. 

The two instances in this PR provide concise, plausible examples of appropriate use of the `Medication.ingredient.strength` extension in accordance with AU Core guidance.

## Validation

Both resources pass the AU Core FHIR validator (`hl7.fhir.au.core#current`, 3.0.0-ci-build) with 0 errors — remaining warnings/notes are the same benign classes already present in existing examples (draft UCUM CodeSystem references, missing narrative, preferred-binding informationals).